### PR TITLE
feat(importer)!: canonical format 1.1.0

### DIFF
--- a/backend/crates/osl_importer/src/bin/import.rs
+++ b/backend/crates/osl_importer/src/bin/import.rs
@@ -85,7 +85,7 @@ async fn handle_canonical_import(
     tracing::info!(
         "Loaded competition: {} (v{})",
         canonical.competition.name,
-        canonical.format_version
+        canonical.source.format_version
     );
 
     tracing::info!("Validating canonical format...");

--- a/backend/crates/osl_importer/src/canonical/models.rs
+++ b/backend/crates/osl_importer/src/canonical/models.rs
@@ -1,56 +1,57 @@
 use chrono::{DateTime, NaiveDate, Utc};
+use osl_domain::{AthleteStatus, SourceType, WeightClassSlug};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CanonicalFormat {
-    pub format_version: String,
     pub source: SourceMetadata,
     pub competition: CompetitionData,
     pub movements: Vec<MovementData>,
     pub categories: Vec<CategoryData>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub liftcontrol_metadata: Option<LiftControlMetadata>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub pdf_metadata: Option<PdfMetadata>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SourceMetadata {
+    pub format_version: String,
+
     #[serde(rename = "type")]
     pub r#type: SourceType,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
+
     pub extracted_at: DateTime<Utc>,
+
     pub extractor: String,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub original_filename: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum SourceType {
-    LiftControl,
-    Pdf,
-    Html,
-    Csv,
-    Manual,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CompetitionData {
     pub name: String,
+
     pub slug: String,
+
     pub federation: FederationData,
+
     pub start_date: NaiveDate,
+
     pub end_date: NaiveDate,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub venue: Option<String>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub city: Option<String>,
+
     pub country: String,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub number_of_judges: Option<i16>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
 }
@@ -58,10 +59,13 @@ pub struct CompetitionData {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FederationData {
     pub name: String,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub slug: Option<String>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub abbreviation: Option<String>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub country: Option<String>,
 }
@@ -69,7 +73,9 @@ pub struct FederationData {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MovementData {
     pub name: String,
+
     pub order: i16,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_required: Option<bool>,
 }
@@ -77,32 +83,47 @@ pub struct MovementData {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CategoryData {
     pub name: String,
+
     pub gender: String,
+
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub weight_class_min: Option<Decimal>,
+    pub weight_class_slug: Option<WeightClassSlug>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub weight_class_max: Option<Decimal>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_open_category: Option<bool>,
+
     pub athletes: Vec<AthleteData>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AthleteData {
     pub first_name: String,
+
     pub last_name: String,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gender: Option<String>,
+
     pub country: String,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nationality: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub team: Option<String>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bodyweight: Option<Decimal>,
+
+    pub status: AthleteStatus,
+
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub is_disqualified: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub disqualified_reason: Option<String>,
+    pub status_reason: Option<String>,
+
     pub lifts: Vec<LiftData>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub liftcontrol_athlete_metadata: Option<LiftControlAthleteMetadata>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -117,29 +138,5 @@ pub struct AttemptData {
     pub weight: Decimal,
     pub is_successful: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub no_rep_reason: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct LiftControlMetadata {
-    pub contest_id: i32,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct LiftControlAthleteMetadata {
-    pub athlete_id: i32,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub reglage_dips: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub reglage_squat: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PdfMetadata {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub extraction_confidence: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub pages_processed: Option<Vec<i32>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub warnings: Option<Vec<String>>,
+    pub judge_note: Option<String>,
 }

--- a/backend/crates/osl_importer/src/canonical/models.rs
+++ b/backend/crates/osl_importer/src/canonical/models.rs
@@ -1,7 +1,10 @@
 use chrono::{DateTime, NaiveDate, Utc};
-use osl_domain::{AthleteStatus, SourceType, WeightClassSlug};
+use osl_domain::{AthleteStatus, WeightClassSlug};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
+
+/// Format version this build reads and writes.
+pub const FORMAT_VERSION: &str = "1.1.0";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CanonicalFormat {
@@ -23,10 +26,31 @@ pub struct SourceMetadata {
 
     pub extracted_at: DateTime<Utc>,
 
+    /// Identifier of the producer, e.g. `liftcontrol-scraper@1.2.0`.
+    ///
+    /// Free text on purpose. This is the only field that names a specific
+    /// source, which is what keeps the rest of the format agnostic.
     pub extractor: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub original_filename: Option<String>,
+}
+
+/// How the data was obtained, not who published it.
+///
+/// Keyed on medium rather than vendor, so a new federation or platform costs
+/// no new variant: liftcontrol and any future results endpoint are both
+/// `Api`, an Instagram result card is `Image`. The producer names itself in
+/// `SourceMetadata::extractor`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceType {
+    Api,
+    Html,
+    Pdf,
+    Csv,
+    Image,
+    Manual,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/backend/crates/osl_importer/src/canonical/transformer.rs
+++ b/backend/crates/osl_importer/src/canonical/transformer.rs
@@ -1,6 +1,7 @@
 use super::models::*;
 use crate::{ImporterError, Result};
 use osl_domain::NormalizedAthleteName;
+use rust_decimal::Decimal;
 use sqlx::PgPool;
 use tracing::info;
 use uuid::Uuid;
@@ -176,7 +177,10 @@ impl<'a> CanonicalTransformer<'a> {
             "#,
             category.name,
             category.gender,
-            category.weight_class_min,
+            // The format states the upper bound only. A category's lower
+            // bound is the class below it, which needs the full ladder, so
+            // it stays null as it already was.
+            None as Option<Decimal>,
             category.weight_class_max
         )
         .fetch_one(&mut **tx)
@@ -196,7 +200,9 @@ impl<'a> CanonicalTransformer<'a> {
     ) -> Result<()> {
         let athlete_id = self.upsert_athlete(athlete, category, tx).await?;
 
-        let is_disqualified = athlete.is_disqualified.unwrap_or(false);
+        // The schema stores the outcome as a flag plus free text. Richer
+        // statuses need a status column, which 1.1.0 does not add.
+        let is_disqualified = athlete.status.is_disqualified();
 
         sqlx::query!(
             r#"
@@ -216,21 +222,14 @@ impl<'a> CanonicalTransformer<'a> {
             athlete.bodyweight,
             None as Option<i32>,
             is_disqualified,
-            athlete.disqualified_reason
+            athlete.status_reason
         )
         .execute(&mut **tx)
         .await?;
 
         for lift in &athlete.lifts {
-            self.import_lift(
-                competition_id,
-                category_id,
-                athlete_id,
-                lift,
-                athlete,
-                &mut *tx,
-            )
-            .await?;
+            self.import_lift(competition_id, category_id, athlete_id, lift, &mut *tx)
+                .await?;
         }
 
         Ok(())
@@ -333,7 +332,6 @@ impl<'a> CanonicalTransformer<'a> {
         category_id: Uuid,
         athlete_id: Uuid,
         lift: &LiftData,
-        athlete: &AthleteData,
         tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     ) -> Result<()> {
         let max_weight = lift
@@ -343,19 +341,10 @@ impl<'a> CanonicalTransformer<'a> {
             .map(|a| a.weight)
             .max();
 
-        let settings = if lift.movement == "Dips" {
-            athlete
-                .liftcontrol_athlete_metadata
-                .as_ref()
-                .and_then(|m| m.reglage_dips.clone())
-        } else if lift.movement == "Squat" {
-            athlete
-                .liftcontrol_athlete_metadata
-                .as_ref()
-                .and_then(|m| m.reglage_squat.clone())
-        } else {
-            None
-        };
+        // Equipment settings came from a liftcontrol-only field. Nothing in
+        // the agnostic format carries them, so the column stays empty until
+        // some source can express it.
+        let settings: Option<String> = None;
 
         let participant = sqlx::query!(
             r#"
@@ -432,7 +421,7 @@ impl<'a> CanonicalTransformer<'a> {
             attempt.weight,
             attempt.is_successful,
             None as Option<i16>,
-            attempt.no_rep_reason,
+            attempt.judge_note,
             "Canonical Importer"
         )
         .execute(&mut **tx)

--- a/backend/crates/osl_importer/src/canonical/validator.rs
+++ b/backend/crates/osl_importer/src/canonical/validator.rs
@@ -1,4 +1,4 @@
-use super::models::CanonicalFormat;
+use super::models::{CanonicalFormat, FORMAT_VERSION};
 use crate::{ImporterError, Result};
 use std::collections::HashSet;
 use tracing::warn;
@@ -9,11 +9,17 @@ impl CanonicalValidator {
     pub fn validate(canonical: &CanonicalFormat) -> Result<ValidationReport> {
         let mut report = ValidationReport::default();
 
-        if canonical.format_version != "1.0.0" {
+        if canonical.source.format_version != FORMAT_VERSION {
             report.errors.push(format!(
-                "Unsupported format version: {}. Expected 1.0.0",
-                canonical.format_version
+                "Unsupported format version: {}. Expected {}",
+                canonical.source.format_version, FORMAT_VERSION
             ));
+        }
+
+        if canonical.source.extractor.is_empty() {
+            report
+                .errors
+                .push("Source extractor is required".to_string());
         }
 
         if canonical.competition.name.is_empty() {
@@ -200,5 +206,117 @@ impl ValidationReport {
         for warning in &self.warnings {
             warn!("{}", warning);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::canonical::models::{
+        AthleteData, AttemptData, CategoryData, CompetitionData, FederationData, LiftData,
+        MovementData, SourceMetadata, SourceType,
+    };
+    use chrono::NaiveDate;
+    use osl_domain::AthleteStatus;
+    use rust_decimal::Decimal;
+
+    fn minimal() -> CanonicalFormat {
+        CanonicalFormat {
+            source: SourceMetadata {
+                format_version: FORMAT_VERSION.to_string(),
+                r#type: SourceType::Image,
+                url: None,
+                extracted_at: chrono::Utc::now(),
+                extractor: "test-extractor@1.0.0".to_string(),
+                original_filename: None,
+            },
+            competition: CompetitionData {
+                name: "Test Open".to_string(),
+                slug: "test-open".to_string(),
+                federation: FederationData {
+                    name: "Test Federation".to_string(),
+                    slug: None,
+                    abbreviation: None,
+                    country: None,
+                },
+                start_date: NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+                end_date: NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+                venue: None,
+                city: None,
+                country: "FR".to_string(),
+                number_of_judges: Some(3),
+                status: None,
+            },
+            movements: vec![MovementData {
+                name: "Squat".to_string(),
+                order: 1,
+                is_required: Some(true),
+            }],
+            categories: vec![CategoryData {
+                name: "M-80".to_string(),
+                gender: "M".to_string(),
+                weight_class_slug: None,
+                weight_class_max: Some(Decimal::from(80)),
+                is_open_category: None,
+                athletes: vec![AthleteData {
+                    first_name: "Adrien".to_string(),
+                    last_name: "Pelfresne".to_string(),
+                    gender: None,
+                    country: "FR".to_string(),
+                    nationality: None,
+                    team: None,
+                    bodyweight: Some(Decimal::from(78)),
+                    status: AthleteStatus::Competed,
+                    status_reason: None,
+                    lifts: vec![LiftData {
+                        movement: "Squat".to_string(),
+                        attempts: vec![AttemptData {
+                            attempt_number: 1,
+                            weight: Decimal::from(100),
+                            is_successful: true,
+                            judge_note: None,
+                        }],
+                    }],
+                }],
+            }],
+        }
+    }
+
+    #[test]
+    fn accepts_a_well_formed_file() {
+        assert!(CanonicalValidator::validate(&minimal()).is_ok());
+    }
+
+    #[test]
+    fn older_format_version_is_rejected() {
+        let mut canonical = minimal();
+        canonical.source.format_version = "1.0.0".to_string();
+
+        let err = CanonicalValidator::validate(&canonical)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Unsupported format version"), "{err}");
+    }
+
+    #[test]
+    fn missing_extractor_is_rejected() {
+        let mut canonical = minimal();
+        canonical.source.extractor = String::new();
+
+        let err = CanonicalValidator::validate(&canonical)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("extractor is required"), "{err}");
+    }
+
+    #[test]
+    fn lift_for_an_undeclared_movement_is_rejected() {
+        let mut canonical = minimal();
+        canonical.categories[0].athletes[0].lifts[0].movement = "Bench".to_string();
+
+        let err = CanonicalValidator::validate(&canonical)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("unknown movement"), "{err}");
     }
 }

--- a/backend/imports/annecy-4-lift-2025/2026-05-22T11-15-23_annecy-4-lift-2025-dimanche-matin-39_liftcontrol.json
+++ b/backend/imports/annecy-4-lift-2025/2026-05-22T11-15-23_annecy-4-lift-2025-dimanche-matin-39_liftcontrol.json
@@ -1,7 +1,7 @@
 {
-  "format_version": "1.0.0",
   "source": {
-    "type": "liftcontrol",
+    "format_version": "1.1.0",
+    "type": "api",
     "url": "https://app.liftcontrol.com/contest/annecy-4-lift-2025-dimanche-matin",
     "extracted_at": "2026-05-22T11:15:23.829688Z",
     "extractor": "liftcontrol-api-v1"
@@ -48,6 +48,7 @@
     {
       "name": "Catégorie +87",
       "gender": "M",
+      "is_open_category": true,
       "athletes": [
         {
           "first_name": "Timothée",
@@ -55,8 +56,7 @@
           "country": "FR",
           "nationality": "French",
           "bodyweight": "88.7",
-          "is_disqualified": false,
-          "disqualified_reason": "",
+          "status": "competed",
           "lifts": [
             {
               "movement": "Muscle-up",
@@ -75,7 +75,7 @@
                   "attempt_number": 3,
                   "weight": "20",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 }
               ]
             },
@@ -139,12 +139,7 @@
                 }
               ]
             }
-          ],
-          "liftcontrol_athlete_metadata": {
-            "athlete_id": 330,
-            "reglage_dips": "12",
-            "reglage_squat": "10"
-          }
+          ]
         },
         {
           "first_name": "Tom",
@@ -152,8 +147,7 @@
           "country": "FR",
           "nationality": "French",
           "bodyweight": "96.9",
-          "is_disqualified": false,
-          "disqualified_reason": "",
+          "status": "competed",
           "lifts": [
             {
               "movement": "Muscle-up",
@@ -172,7 +166,7 @@
                   "attempt_number": 3,
                   "weight": "35",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 }
               ]
             },
@@ -193,7 +187,7 @@
                   "attempt_number": 3,
                   "weight": "95",
                   "is_successful": false,
-                  "no_rep_reason": "Passage du menton"
+                  "judge_note": "Passage du menton"
                 }
               ]
             },
@@ -237,12 +231,7 @@
                 }
               ]
             }
-          ],
-          "liftcontrol_athlete_metadata": {
-            "athlete_id": 328,
-            "reglage_dips": "15",
-            "reglage_squat": "12"
-          }
+          ]
         },
         {
           "first_name": "Alix",
@@ -250,8 +239,7 @@
           "country": "FR",
           "nationality": "French",
           "bodyweight": "94.8",
-          "is_disqualified": false,
-          "disqualified_reason": "",
+          "status": "competed",
           "lifts": [
             {
               "movement": "Muscle-up",
@@ -290,7 +278,7 @@
                   "attempt_number": 3,
                   "weight": "100",
                   "is_successful": true,
-                  "no_rep_reason": "Passage du menton"
+                  "judge_note": "Passage du menton"
                 }
               ]
             },
@@ -334,12 +322,7 @@
                 }
               ]
             }
-          ],
-          "liftcontrol_athlete_metadata": {
-            "athlete_id": 327,
-            "reglage_dips": "13",
-            "reglage_squat": "13"
-          }
+          ]
         },
         {
           "first_name": "Loïck",
@@ -347,8 +330,7 @@
           "country": "FR",
           "nationality": "French",
           "bodyweight": "92.1",
-          "is_disqualified": false,
-          "disqualified_reason": "",
+          "status": "competed",
           "lifts": [
             {
               "movement": "Muscle-up",
@@ -427,16 +409,11 @@
                   "attempt_number": 3,
                   "weight": "185",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 }
               ]
             }
-          ],
-          "liftcontrol_athlete_metadata": {
-            "athlete_id": 333,
-            "reglage_dips": "12",
-            "reglage_squat": "13"
-          }
+          ]
         },
         {
           "first_name": "Alex",
@@ -444,8 +421,7 @@
           "country": "FR",
           "nationality": "French",
           "bodyweight": "94.7",
-          "is_disqualified": false,
-          "disqualified_reason": "",
+          "status": "competed",
           "lifts": [
             {
               "movement": "Muscle-up",
@@ -464,7 +440,7 @@
                   "attempt_number": 3,
                   "weight": "10",
                   "is_successful": false,
-                  "no_rep_reason": "Flexion de genoux"
+                  "judge_note": "Flexion de genoux"
                 }
               ]
             },
@@ -475,7 +451,7 @@
                   "attempt_number": 1,
                   "weight": "70",
                   "is_successful": true,
-                  "no_rep_reason": "Flexion de genoux"
+                  "judge_note": "Flexion de genoux"
                 },
                 {
                   "attempt_number": 2,
@@ -506,7 +482,7 @@
                   "attempt_number": 3,
                   "weight": "100",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 }
               ]
             },
@@ -522,7 +498,7 @@
                   "attempt_number": 2,
                   "weight": "185",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 },
                 {
                   "attempt_number": 3,
@@ -531,12 +507,7 @@
                 }
               ]
             }
-          ],
-          "liftcontrol_athlete_metadata": {
-            "athlete_id": 325,
-            "reglage_dips": "13",
-            "reglage_squat": "15"
-          }
+          ]
         },
         {
           "first_name": "Adrien",
@@ -544,8 +515,7 @@
           "country": "FR",
           "nationality": "French",
           "bodyweight": "93.8",
-          "is_disqualified": false,
-          "disqualified_reason": "",
+          "status": "competed",
           "lifts": [
             {
               "movement": "Muscle-up",
@@ -627,12 +597,7 @@
                 }
               ]
             }
-          ],
-          "liftcontrol_athlete_metadata": {
-            "athlete_id": 331,
-            "reglage_dips": "14",
-            "reglage_squat": "16"
-          }
+          ]
         },
         {
           "first_name": "Antoine",
@@ -640,8 +605,7 @@
           "country": "FR",
           "nationality": "French",
           "bodyweight": "88.2",
-          "is_disqualified": false,
-          "disqualified_reason": "",
+          "status": "competed",
           "lifts": [
             {
               "movement": "Muscle-up",
@@ -660,7 +624,7 @@
                   "attempt_number": 3,
                   "weight": "10",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 }
               ]
             },
@@ -681,7 +645,7 @@
                   "attempt_number": 3,
                   "weight": "50",
                   "is_successful": false,
-                  "no_rep_reason": "Passage du menton"
+                  "judge_note": "Passage du menton"
                 }
               ]
             },
@@ -702,7 +666,7 @@
                   "attempt_number": 3,
                   "weight": "80",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 }
               ]
             },
@@ -726,12 +690,7 @@
                 }
               ]
             }
-          ],
-          "liftcontrol_athlete_metadata": {
-            "athlete_id": 332,
-            "reglage_dips": "13",
-            "reglage_squat": "16"
-          }
+          ]
         },
         {
           "first_name": "Aghiles",
@@ -739,8 +698,7 @@
           "country": "FR",
           "nationality": "French",
           "bodyweight": "94.7",
-          "is_disqualified": false,
-          "disqualified_reason": "",
+          "status": "competed",
           "lifts": [
             {
               "movement": "Muscle-up",
@@ -779,7 +737,7 @@
                   "attempt_number": 3,
                   "weight": "76.25",
                   "is_successful": false,
-                  "no_rep_reason": "Passage du menton"
+                  "judge_note": "Passage du menton"
                 }
               ]
             },
@@ -800,7 +758,7 @@
                   "attempt_number": 3,
                   "weight": "147.5",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 }
               ]
             },
@@ -824,12 +782,7 @@
                 }
               ]
             }
-          ],
-          "liftcontrol_athlete_metadata": {
-            "athlete_id": 329,
-            "reglage_dips": "15",
-            "reglage_squat": "14"
-          }
+          ]
         },
         {
           "first_name": "Gwendal",
@@ -837,8 +790,7 @@
           "country": "FR",
           "nationality": "French",
           "bodyweight": "88.8",
-          "is_disqualified": false,
-          "disqualified_reason": "",
+          "status": "competed",
           "lifts": [
             {
               "movement": "Muscle-up",
@@ -847,7 +799,7 @@
                   "attempt_number": 1,
                   "weight": "15",
                   "is_successful": true,
-                  "no_rep_reason": "Flexion de genoux"
+                  "judge_note": "Flexion de genoux"
                 },
                 {
                   "attempt_number": 2,
@@ -858,7 +810,7 @@
                   "attempt_number": 3,
                   "weight": "22.5",
                   "is_successful": true,
-                  "no_rep_reason": "Flexion de genoux"
+                  "judge_note": "Flexion de genoux"
                 }
               ]
             },
@@ -899,7 +851,7 @@
                   "attempt_number": 3,
                   "weight": "135",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 }
               ]
             },
@@ -920,16 +872,11 @@
                   "attempt_number": 3,
                   "weight": "200",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 }
               ]
             }
-          ],
-          "liftcontrol_athlete_metadata": {
-            "athlete_id": 326,
-            "reglage_dips": "9",
-            "reglage_squat": "15"
-          }
+          ]
         }
       ]
     },
@@ -944,8 +891,7 @@
           "country": "FR",
           "nationality": "French",
           "bodyweight": "78.4",
-          "is_disqualified": false,
-          "disqualified_reason": "",
+          "status": "competed",
           "lifts": [
             {
               "movement": "Muscle-up",
@@ -959,7 +905,7 @@
                   "attempt_number": 2,
                   "weight": "20",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 },
                 {
                   "attempt_number": 3,
@@ -985,7 +931,7 @@
                   "attempt_number": 3,
                   "weight": "62.5",
                   "is_successful": false,
-                  "no_rep_reason": "Non-respect des ordres"
+                  "judge_note": "Non-respect des ordres"
                 }
               ]
             },
@@ -996,7 +942,7 @@
                   "attempt_number": 1,
                   "weight": "95",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 },
                 {
                   "attempt_number": 2,
@@ -1030,12 +976,7 @@
                 }
               ]
             }
-          ],
-          "liftcontrol_athlete_metadata": {
-            "athlete_id": 321,
-            "reglage_dips": "7",
-            "reglage_squat": "11"
-          }
+          ]
         },
         {
           "first_name": "Gaëtan",
@@ -1043,8 +984,7 @@
           "country": "FR",
           "nationality": "French",
           "bodyweight": "74.9",
-          "is_disqualified": false,
-          "disqualified_reason": "",
+          "status": "competed",
           "lifts": [
             {
               "movement": "Muscle-up",
@@ -1063,7 +1003,7 @@
                   "attempt_number": 3,
                   "weight": "27.5",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 }
               ]
             },
@@ -1084,7 +1024,7 @@
                   "attempt_number": 3,
                   "weight": "70",
                   "is_successful": false,
-                  "no_rep_reason": "Passage du menton"
+                  "judge_note": "Passage du menton"
                 }
               ]
             },
@@ -1095,7 +1035,7 @@
                   "attempt_number": 1,
                   "weight": "92.5",
                   "is_successful": false,
-                  "no_rep_reason": "Amplitude hanches"
+                  "judge_note": "Amplitude hanches"
                 },
                 {
                   "attempt_number": 2,
@@ -1126,16 +1066,11 @@
                   "attempt_number": 3,
                   "weight": "200",
                   "is_successful": false,
-                  "no_rep_reason": "Barre tombée"
+                  "judge_note": "Barre tombée"
                 }
               ]
             }
-          ],
-          "liftcontrol_athlete_metadata": {
-            "athlete_id": 320,
-            "reglage_dips": "10",
-            "reglage_squat": "11"
-          }
+          ]
         },
         {
           "first_name": "Loyan",
@@ -1143,8 +1078,7 @@
           "country": "FR",
           "nationality": "French",
           "bodyweight": "76.1",
-          "is_disqualified": false,
-          "disqualified_reason": "",
+          "status": "competed",
           "lifts": [
             {
               "movement": "Muscle-up",
@@ -1158,13 +1092,13 @@
                   "attempt_number": 2,
                   "weight": "15",
                   "is_successful": false,
-                  "no_rep_reason": "Utilisation d’un False Grip"
+                  "judge_note": "Utilisation d’un False Grip"
                 },
                 {
                   "attempt_number": 3,
                   "weight": "15",
                   "is_successful": true,
-                  "no_rep_reason": "Utilisation d’un False Grip"
+                  "judge_note": "Utilisation d’un False Grip"
                 }
               ]
             },
@@ -1180,13 +1114,13 @@
                   "attempt_number": 2,
                   "weight": "55",
                   "is_successful": true,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 },
                 {
                   "attempt_number": 3,
                   "weight": "57.5",
                   "is_successful": true,
-                  "no_rep_reason": "Passage du menton"
+                  "judge_note": "Passage du menton"
                 }
               ]
             },
@@ -1230,12 +1164,7 @@
                 }
               ]
             }
-          ],
-          "liftcontrol_athlete_metadata": {
-            "athlete_id": 314,
-            "reglage_dips": "11",
-            "reglage_squat": "15"
-          }
+          ]
         },
         {
           "first_name": "Richard",
@@ -1243,8 +1172,7 @@
           "country": "FR",
           "nationality": "French",
           "bodyweight": "75.6",
-          "is_disqualified": false,
-          "disqualified_reason": "",
+          "status": "competed",
           "lifts": [
             {
               "movement": "Muscle-up",
@@ -1253,7 +1181,7 @@
                   "attempt_number": 1,
                   "weight": "16.25",
                   "is_successful": false,
-                  "no_rep_reason": "Cassage des hanches"
+                  "judge_note": "Cassage des hanches"
                 },
                 {
                   "attempt_number": 2,
@@ -1284,7 +1212,7 @@
                   "attempt_number": 3,
                   "weight": "72.5",
                   "is_successful": false,
-                  "no_rep_reason": "Passage du menton"
+                  "judge_note": "Passage du menton"
                 }
               ]
             },
@@ -1305,7 +1233,7 @@
                   "attempt_number": 3,
                   "weight": "117.5",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 }
               ]
             },
@@ -1329,12 +1257,7 @@
                 }
               ]
             }
-          ],
-          "liftcontrol_athlete_metadata": {
-            "athlete_id": 319,
-            "reglage_dips": "13",
-            "reglage_squat": "12"
-          }
+          ]
         },
         {
           "first_name": "Anaël",
@@ -1342,8 +1265,7 @@
           "country": "FR",
           "nationality": "French",
           "bodyweight": "79.2",
-          "is_disqualified": false,
-          "disqualified_reason": "",
+          "status": "competed",
           "lifts": [
             {
               "movement": "Muscle-up",
@@ -1377,7 +1299,7 @@
                   "attempt_number": 2,
                   "weight": "60",
                   "is_successful": false,
-                  "no_rep_reason": "Non-respect des ordres"
+                  "judge_note": "Non-respect des ordres"
                 },
                 {
                   "attempt_number": 3,
@@ -1403,7 +1325,7 @@
                   "attempt_number": 3,
                   "weight": "100",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 }
               ]
             },
@@ -1424,16 +1346,11 @@
                   "attempt_number": 3,
                   "weight": "200",
                   "is_successful": true,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 }
               ]
             }
-          ],
-          "liftcontrol_athlete_metadata": {
-            "athlete_id": 316,
-            "reglage_dips": "15",
-            "reglage_squat": "12"
-          }
+          ]
         },
         {
           "first_name": "Ilyes",
@@ -1441,8 +1358,7 @@
           "country": "FR",
           "nationality": "French",
           "bodyweight": "75.5",
-          "is_disqualified": false,
-          "disqualified_reason": "",
+          "status": "competed",
           "lifts": [
             {
               "movement": "Muscle-up",
@@ -1481,7 +1397,7 @@
                   "attempt_number": 3,
                   "weight": "60",
                   "is_successful": false,
-                  "no_rep_reason": "Passage du menton"
+                  "judge_note": "Passage du menton"
                 }
               ]
             },
@@ -1525,12 +1441,7 @@
                 }
               ]
             }
-          ],
-          "liftcontrol_athlete_metadata": {
-            "athlete_id": 313,
-            "reglage_dips": "14",
-            "reglage_squat": "13"
-          }
+          ]
         },
         {
           "first_name": "Alexis",
@@ -1538,8 +1449,7 @@
           "country": "FR",
           "nationality": "French",
           "bodyweight": "76.5",
-          "is_disqualified": false,
-          "disqualified_reason": "",
+          "status": "competed",
           "lifts": [
             {
               "movement": "Muscle-up",
@@ -1578,7 +1488,7 @@
                   "attempt_number": 3,
                   "weight": "55",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 }
               ]
             },
@@ -1622,12 +1532,7 @@
                 }
               ]
             }
-          ],
-          "liftcontrol_athlete_metadata": {
-            "athlete_id": 323,
-            "reglage_dips": "9",
-            "reglage_squat": "13"
-          }
+          ]
         },
         {
           "first_name": "Hugo",
@@ -1635,8 +1540,7 @@
           "country": "FR",
           "nationality": "French",
           "bodyweight": "74.6",
-          "is_disqualified": false,
-          "disqualified_reason": "",
+          "status": "competed",
           "lifts": [
             {
               "movement": "Muscle-up",
@@ -1695,7 +1599,7 @@
                   "attempt_number": 3,
                   "weight": "90",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 }
               ]
             },
@@ -1719,12 +1623,7 @@
                 }
               ]
             }
-          ],
-          "liftcontrol_athlete_metadata": {
-            "athlete_id": 317,
-            "reglage_dips": "10",
-            "reglage_squat": "13"
-          }
+          ]
         },
         {
           "first_name": "François",
@@ -1732,8 +1631,7 @@
           "country": "FR",
           "nationality": "French",
           "bodyweight": "76.2",
-          "is_disqualified": false,
-          "disqualified_reason": "",
+          "status": "competed",
           "lifts": [
             {
               "movement": "Muscle-up",
@@ -1747,13 +1645,13 @@
                   "attempt_number": 2,
                   "weight": "10",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 },
                 {
                   "attempt_number": 3,
                   "weight": "10",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 }
               ]
             },
@@ -1769,7 +1667,7 @@
                   "attempt_number": 2,
                   "weight": "55",
                   "is_successful": false,
-                  "no_rep_reason": "Non-respect des ordres"
+                  "judge_note": "Non-respect des ordres"
                 },
                 {
                   "attempt_number": 3,
@@ -1795,7 +1693,7 @@
                   "attempt_number": 3,
                   "weight": "90",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 }
               ]
             },
@@ -1811,22 +1709,17 @@
                   "attempt_number": 2,
                   "weight": "172.5",
                   "is_successful": false,
-                  "no_rep_reason": "Non-respect des ordres"
+                  "judge_note": "Non-respect des ordres"
                 },
                 {
                   "attempt_number": 3,
                   "weight": "180",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 }
               ]
             }
-          ],
-          "liftcontrol_athlete_metadata": {
-            "athlete_id": 324,
-            "reglage_dips": "10",
-            "reglage_squat": "13"
-          }
+          ]
         },
         {
           "first_name": "Remy",
@@ -1834,8 +1727,7 @@
           "country": "FR",
           "nationality": "French",
           "bodyweight": "77.9",
-          "is_disqualified": false,
-          "disqualified_reason": "",
+          "status": "competed",
           "lifts": [
             {
               "movement": "Muscle-up",
@@ -1854,7 +1746,7 @@
                   "attempt_number": 3,
                   "weight": "20",
                   "is_successful": true,
-                  "no_rep_reason": "Flexion de genoux"
+                  "judge_note": "Flexion de genoux"
                 }
               ]
             },
@@ -1918,12 +1810,7 @@
                 }
               ]
             }
-          ],
-          "liftcontrol_athlete_metadata": {
-            "athlete_id": 310,
-            "reglage_dips": "13",
-            "reglage_squat": "11"
-          }
+          ]
         },
         {
           "first_name": "Morgan",
@@ -1931,8 +1818,7 @@
           "country": "FR",
           "nationality": "French",
           "bodyweight": "77.6",
-          "is_disqualified": false,
-          "disqualified_reason": "",
+          "status": "competed",
           "lifts": [
             {
               "movement": "Muscle-up",
@@ -1951,7 +1837,7 @@
                   "attempt_number": 3,
                   "weight": "20",
                   "is_successful": true,
-                  "no_rep_reason": "Flexion de genoux"
+                  "judge_note": "Flexion de genoux"
                 }
               ]
             },
@@ -1967,7 +1853,7 @@
                   "attempt_number": 2,
                   "weight": "60",
                   "is_successful": false,
-                  "no_rep_reason": "Non-respect des ordres"
+                  "judge_note": "Non-respect des ordres"
                 },
                 {
                   "attempt_number": 3,
@@ -1993,7 +1879,7 @@
                   "attempt_number": 3,
                   "weight": "100",
                   "is_successful": false,
-                  "no_rep_reason": "Amplitude épaules"
+                  "judge_note": "Amplitude épaules"
                 }
               ]
             },
@@ -2009,22 +1895,17 @@
                   "attempt_number": 2,
                   "weight": "167.5",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 },
                 {
                   "attempt_number": 3,
                   "weight": "180",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 }
               ]
             }
-          ],
-          "liftcontrol_athlete_metadata": {
-            "athlete_id": 322,
-            "reglage_dips": "12",
-            "reglage_squat": "12"
-          }
+          ]
         },
         {
           "first_name": "Nassim",
@@ -2032,8 +1913,7 @@
           "country": "FR",
           "nationality": "French",
           "bodyweight": "76.2",
-          "is_disqualified": false,
-          "disqualified_reason": "",
+          "status": "competed",
           "lifts": [
             {
               "movement": "Muscle-up",
@@ -2052,7 +1932,7 @@
                   "attempt_number": 3,
                   "weight": "31.25",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 }
               ]
             },
@@ -2088,13 +1968,13 @@
                   "attempt_number": 2,
                   "weight": "92.5",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 },
                 {
                   "attempt_number": 3,
                   "weight": "92.5",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 }
               ]
             },
@@ -2115,16 +1995,11 @@
                   "attempt_number": 3,
                   "weight": "217.5",
                   "is_successful": false,
-                  "no_rep_reason": "Barre tombée"
+                  "judge_note": "Barre tombée"
                 }
               ]
             }
-          ],
-          "liftcontrol_athlete_metadata": {
-            "athlete_id": 311,
-            "reglage_dips": "12",
-            "reglage_squat": "11"
-          }
+          ]
         },
         {
           "first_name": "Alexandre",
@@ -2132,8 +2007,7 @@
           "country": "FR",
           "nationality": "French",
           "bodyweight": "78.2",
-          "is_disqualified": false,
-          "disqualified_reason": "",
+          "status": "competed",
           "lifts": [
             {
               "movement": "Muscle-up",
@@ -2212,16 +2086,11 @@
                   "attempt_number": 3,
                   "weight": "182.5",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 }
               ]
             }
-          ],
-          "liftcontrol_athlete_metadata": {
-            "athlete_id": 312,
-            "reglage_dips": "12",
-            "reglage_squat": "11"
-          }
+          ]
         },
         {
           "first_name": "Noé",
@@ -2229,8 +2098,7 @@
           "country": "FR",
           "nationality": "French",
           "bodyweight": "78.6",
-          "is_disqualified": false,
-          "disqualified_reason": "",
+          "status": "competed",
           "lifts": [
             {
               "movement": "Muscle-up",
@@ -2249,7 +2117,7 @@
                   "attempt_number": 3,
                   "weight": "20",
                   "is_successful": true,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 }
               ]
             },
@@ -2265,7 +2133,7 @@
                   "attempt_number": 2,
                   "weight": "60",
                   "is_successful": true,
-                  "no_rep_reason": "Passage du menton"
+                  "judge_note": "Passage du menton"
                 },
                 {
                   "attempt_number": 3,
@@ -2311,16 +2179,11 @@
                   "attempt_number": 3,
                   "weight": "205",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 }
               ]
             }
-          ],
-          "liftcontrol_athlete_metadata": {
-            "athlete_id": 315,
-            "reglage_dips": "10",
-            "reglage_squat": "11"
-          }
+          ]
         },
         {
           "first_name": "Thibault",
@@ -2328,8 +2191,7 @@
           "country": "FR",
           "nationality": "French",
           "bodyweight": "79.9",
-          "is_disqualified": false,
-          "disqualified_reason": "",
+          "status": "competed",
           "lifts": [
             {
               "movement": "Muscle-up",
@@ -2348,7 +2210,7 @@
                   "attempt_number": 3,
                   "weight": "28.5",
                   "is_successful": false,
-                  "no_rep_reason": "Positionnement non-conforme des poids"
+                  "judge_note": "Positionnement non-conforme des poids"
                 }
               ]
             },
@@ -2384,13 +2246,13 @@
                   "attempt_number": 2,
                   "weight": "100",
                   "is_successful": false,
-                  "no_rep_reason": "Amplitude hanches"
+                  "judge_note": "Amplitude hanches"
                 },
                 {
                   "attempt_number": 3,
                   "weight": "102.5",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 }
               ]
             },
@@ -2406,27 +2268,19 @@
                   "attempt_number": 2,
                   "weight": "0.02",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 },
                 {
                   "attempt_number": 3,
                   "weight": "0.02",
                   "is_successful": false,
-                  "no_rep_reason": "[Autre]"
+                  "judge_note": "[Autre]"
                 }
               ]
             }
-          ],
-          "liftcontrol_athlete_metadata": {
-            "athlete_id": 318,
-            "reglage_dips": "12",
-            "reglage_squat": "13"
-          }
+          ]
         }
       ]
     }
-  ],
-  "liftcontrol_metadata": {
-    "contest_id": 39
-  }
+  ]
 }


### PR DESCRIPTION
Drops the liftcontrol and pdf metadata blocks, so no source name appears in the format anymore. Source type is now the medium (api, html, pdf, csv, image, manual).

Athlete outcome moves from is_disqualified to a status enum, and no_rep_reason becomes judge_note.