### PR TITLE
ci: use a github app token for release-please

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -9,13 +9,20 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # A GitHub App token instead of a PAT, because a PAT expires and takes
+      # releases down with it until someone notices.
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
       - uses: actions/checkout@v7
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
       - uses: googleapis/release-please-action@v5
         id: release
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
       - if: ${{ steps.release.outputs.pr }}
@@ -25,7 +32,7 @@ jobs:
       - if: ${{ steps.release.outputs.pr }}
         name: Update Cargo.lock after version bump
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh pr checkout ${{ fromJson(steps.release.outputs.pr).number }}
           cargo generate-lockfile --manifest-path backend/Cargo.toml


### PR DESCRIPTION
The PAT expired on 2026-06-24, which is why checkout has been failing with `could not read Username` since late June.

App tokens do not expire. Needs RELEASE_PLEASE_APP_ID and RELEASE_PLEASE_PRIVATE_KEY set before merging.