### PR TITLE
feat(importer): add import fmt

### DIFF
--- a/.github/workflows/ci-backend.yaml
+++ b/.github/workflows/ci-backend.yaml
@@ -26,6 +26,25 @@ jobs:
         working-directory: backend
         run: cargo fmt --all -- --check
 
+  imports:
+    name: Import files
+    runs-on: ubuntu-latest
+    env:
+      SQLX_OFFLINE: true
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-workspaces: backend
+      # Canonical files are reviewed as diffs, so an unformatted one makes a
+      # small change look like a rewrite.
+      - name: Check canonical files are formatted
+        working-directory: backend
+        run: cargo run -p osl_importer --bin import -- fmt --check
+      - name: Validate canonical files
+        working-directory: backend
+        run: cargo run -p osl_importer --bin import -- bulk-import --validate-only
+
   lint:
     name: Clippy
     runs-on: ubuntu-latest
@@ -79,7 +98,7 @@ jobs:
     name: CI Success
     runs-on: ubuntu-latest
     if: always()
-    needs: [format, lint, test]
+    needs: [format, imports, lint, test]
     steps:
       - name: Check all jobs passed
         run: |

--- a/backend/crates/osl_importer/src/bin/import.rs
+++ b/backend/crates/osl_importer/src/bin/import.rs
@@ -1,9 +1,10 @@
 use clap::{Parser, Subcommand};
 use osl_importer::canonical::{
-    models::CanonicalFormat, transformer::CanonicalTransformer, validator::CanonicalValidator,
+    format as canonical_format, models::CanonicalFormat, transformer::CanonicalTransformer,
+    validator::CanonicalValidator,
 };
 use sqlx::postgres::PgPoolOptions;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[derive(Parser)]
@@ -14,8 +15,9 @@ struct Cli {
     #[command(subcommand)]
     command: Commands,
 
+    /// Optional because `fmt` never touches the database.
     #[arg(long, env = "DATABASE_URL")]
-    database_url: String,
+    database_url: Option<String>,
 
     #[arg(short, long)]
     verbose: bool,
@@ -35,6 +37,16 @@ enum Commands {
 
         #[arg(long)]
         validate_only: bool,
+    },
+    /// Rewrite canonical files in their canonical shape.
+    Fmt {
+        /// Files or directories. Directories are searched for .json.
+        #[arg(default_value = "./imports")]
+        paths: Vec<PathBuf>,
+
+        /// Report files that would change instead of rewriting them.
+        #[arg(long)]
+        check: bool,
     },
 }
 
@@ -59,16 +71,82 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             file,
             validate_only,
         } => {
-            handle_canonical_import(file, validate_only, &cli.database_url).await?;
+            let database_url = require_database_url(cli.database_url.as_deref(), validate_only)?;
+            handle_canonical_import(file, validate_only, database_url).await?;
         }
         Commands::BulkImport {
             directory,
             validate_only,
         } => {
-            handle_bulk_import(directory, validate_only, &cli.database_url).await?;
+            let database_url = require_database_url(cli.database_url.as_deref(), validate_only)?;
+            handle_bulk_import(directory, validate_only, database_url).await?;
+        }
+        Commands::Fmt { paths, check } => {
+            handle_fmt(&paths, check).await?;
         }
     }
 
+    Ok(())
+}
+
+fn require_database_url(
+    database_url: Option<&str>,
+    validate_only: bool,
+) -> Result<&str, Box<dyn std::error::Error>> {
+    match database_url {
+        Some(url) => Ok(url),
+        None if validate_only => Ok(""),
+        None => Err("DATABASE_URL is required to import. Pass --validate-only to skip it".into()),
+    }
+}
+
+async fn handle_fmt(paths: &[PathBuf], check: bool) -> Result<(), Box<dyn std::error::Error>> {
+    let mut files = Vec::new();
+    for path in paths {
+        collect_json_files(path, &mut files).await?;
+    }
+    files.sort();
+
+    if files.is_empty() {
+        tracing::warn!("No JSON files found");
+        return Ok(());
+    }
+
+    let mut changed = Vec::new();
+    for file in &files {
+        let original = tokio::fs::read_to_string(file).await?;
+        let mut canonical: CanonicalFormat = serde_json::from_str(&original)?;
+        canonical_format::normalize(&mut canonical);
+        let formatted = canonical_format::to_string(&canonical)?;
+
+        if formatted == original {
+            continue;
+        }
+
+        changed.push(file.clone());
+        if !check {
+            tokio::fs::write(file, formatted).await?;
+        }
+    }
+
+    if changed.is_empty() {
+        tracing::info!("{} file(s) already formatted", files.len());
+        return Ok(());
+    }
+
+    for file in &changed {
+        tracing::info!("{}", file.display());
+    }
+
+    if check {
+        return Err(format!(
+            "{} file(s) are not formatted. Run `import fmt` to fix",
+            changed.len()
+        )
+        .into());
+    }
+
+    tracing::info!("Formatted {} file(s)", changed.len());
     Ok(())
 }
 
@@ -115,6 +193,30 @@ async fn handle_canonical_import(
     Ok(())
 }
 
+/// Gathers every .json under `path`, or `path` itself when it is a file.
+async fn collect_json_files(
+    path: &Path,
+    found: &mut Vec<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut pending = vec![path.to_path_buf()];
+
+    while let Some(current) = pending.pop() {
+        if !current.is_dir() {
+            if current.extension().is_some_and(|ext| ext == "json") {
+                found.push(current);
+            }
+            continue;
+        }
+
+        let mut entries = tokio::fs::read_dir(&current).await?;
+        while let Some(entry) = entries.next_entry().await? {
+            pending.push(entry.path());
+        }
+    }
+
+    Ok(())
+}
+
 async fn handle_bulk_import(
     directory: PathBuf,
     validate_only: bool,
@@ -126,22 +228,7 @@ async fn handle_bulk_import(
     );
 
     let mut json_files = Vec::new();
-    let mut entries = tokio::fs::read_dir(&directory).await?;
-
-    while let Some(entry) = entries.next_entry().await? {
-        let path = entry.path();
-        if path.is_dir() {
-            let mut sub_entries = tokio::fs::read_dir(&path).await?;
-            while let Some(sub_entry) = sub_entries.next_entry().await? {
-                let sub_path = sub_entry.path();
-                if sub_path.extension().is_some_and(|ext| ext == "json") {
-                    json_files.push(sub_path);
-                }
-            }
-        } else if path.extension().is_some_and(|ext| ext == "json") {
-            json_files.push(path);
-        }
-    }
+    collect_json_files(&directory, &mut json_files).await?;
 
     if json_files.is_empty() {
         tracing::warn!("No JSON files found in {}", directory.display());

--- a/backend/crates/osl_importer/src/canonical/format.rs
+++ b/backend/crates/osl_importer/src/canonical/format.rs
@@ -1,0 +1,249 @@
+//! Deterministic on-disk shape for canonical files.
+//!
+//! A competition file is built up over many edits, and the review is the git
+//! diff. If key order or decimal scale drifts between writes, a change that
+//! adds eight athletes shows up as a rewrite of the whole file and stops
+//! being reviewable. Running every file through here keeps a diff to the
+//! bricks that were actually added.
+
+use std::collections::HashMap;
+
+use super::models::CanonicalFormat;
+
+/// Reorders a file into its canonical shape.
+///
+/// Order is not meaningful anywhere in the format: rank is recomputed from
+/// the lifts, so nothing here changes what gets imported.
+pub fn normalize(canonical: &mut CanonicalFormat) {
+    canonical
+        .movements
+        .sort_by(|a, b| a.order.cmp(&b.order).then_with(|| a.name.cmp(&b.name)));
+
+    let movement_order: HashMap<&str, i16> = canonical
+        .movements
+        .iter()
+        .map(|m| (m.name.as_str(), m.order))
+        .collect();
+
+    // Sorting borrows the map above, so the order is captured first.
+    let movement_order: HashMap<String, i16> = movement_order
+        .into_iter()
+        .map(|(name, order)| (name.to_owned(), order))
+        .collect();
+
+    canonical.categories.sort_by(|a, b| a.name.cmp(&b.name));
+
+    for category in &mut canonical.categories {
+        if let Some(max) = category.weight_class_max.as_mut() {
+            *max = max.normalize();
+        }
+
+        category.athletes.sort_by(|a, b| {
+            a.last_name
+                .cmp(&b.last_name)
+                .then_with(|| a.first_name.cmp(&b.first_name))
+        });
+
+        for athlete in &mut category.athletes {
+            if let Some(bodyweight) = athlete.bodyweight.as_mut() {
+                *bodyweight = bodyweight.normalize();
+            }
+
+            athlete.lifts.sort_by(|a, b| {
+                let left = movement_order.get(&a.movement).copied().unwrap_or(i16::MAX);
+                let right = movement_order.get(&b.movement).copied().unwrap_or(i16::MAX);
+                left.cmp(&right).then_with(|| a.movement.cmp(&b.movement))
+            });
+
+            for lift in &mut athlete.lifts {
+                lift.attempts.sort_by_key(|a| a.attempt_number);
+                for attempt in &mut lift.attempts {
+                    attempt.weight = attempt.weight.normalize();
+                }
+            }
+        }
+    }
+}
+
+/// Renders a normalized file as the bytes we write to disk.
+pub fn to_string(canonical: &CanonicalFormat) -> serde_json::Result<String> {
+    let mut rendered = serde_json::to_string_pretty(canonical)?;
+    rendered.push('\n');
+    Ok(rendered)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::canonical::models::{
+        AthleteData, AttemptData, CategoryData, CompetitionData, FORMAT_VERSION, FederationData,
+        LiftData, MovementData, SourceMetadata, SourceType,
+    };
+    use chrono::NaiveDate;
+    use osl_domain::AthleteStatus;
+    use rust_decimal::Decimal;
+    use std::str::FromStr;
+
+    fn athlete(first: &str, last: &str, movements: &[&str]) -> AthleteData {
+        AthleteData {
+            first_name: first.to_string(),
+            last_name: last.to_string(),
+            gender: None,
+            country: "FR".to_string(),
+            nationality: None,
+            team: None,
+            bodyweight: Some(Decimal::from_str("78.50").unwrap()),
+            status: AthleteStatus::Competed,
+            status_reason: None,
+            lifts: movements
+                .iter()
+                .map(|m| LiftData {
+                    movement: (*m).to_string(),
+                    attempts: vec![
+                        AttemptData {
+                            attempt_number: 3,
+                            weight: Decimal::from_str("100.00").unwrap(),
+                            is_successful: false,
+                            judge_note: None,
+                        },
+                        AttemptData {
+                            attempt_number: 1,
+                            weight: Decimal::from(80),
+                            is_successful: true,
+                            judge_note: None,
+                        },
+                    ],
+                })
+                .collect(),
+        }
+    }
+
+    fn unsorted() -> CanonicalFormat {
+        CanonicalFormat {
+            source: SourceMetadata {
+                format_version: FORMAT_VERSION.to_string(),
+                r#type: SourceType::Image,
+                url: None,
+                extracted_at: chrono::Utc::now(),
+                extractor: "test@1.0.0".to_string(),
+                original_filename: None,
+            },
+            competition: CompetitionData {
+                name: "Test Open".to_string(),
+                slug: "test-open".to_string(),
+                federation: FederationData {
+                    name: "Test Federation".to_string(),
+                    slug: None,
+                    abbreviation: None,
+                    country: None,
+                },
+                start_date: NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+                end_date: NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+                venue: None,
+                city: None,
+                country: "FR".to_string(),
+                number_of_judges: Some(3),
+                status: None,
+            },
+            movements: vec![
+                MovementData {
+                    name: "Squat".to_string(),
+                    order: 4,
+                    is_required: Some(true),
+                },
+                MovementData {
+                    name: "Muscle-up".to_string(),
+                    order: 1,
+                    is_required: Some(true),
+                },
+            ],
+            categories: vec![
+                CategoryData {
+                    name: "M-87".to_string(),
+                    gender: "M".to_string(),
+                    weight_class_slug: None,
+                    weight_class_max: Some(Decimal::from_str("87.0").unwrap()),
+                    is_open_category: None,
+                    athletes: vec![
+                        athlete("Bob", "Zulu", &["Squat", "Muscle-up"]),
+                        athlete("Alice", "Alpha", &["Squat", "Muscle-up"]),
+                    ],
+                },
+                CategoryData {
+                    name: "M-80".to_string(),
+                    gender: "M".to_string(),
+                    weight_class_slug: None,
+                    weight_class_max: Some(Decimal::from(80)),
+                    is_open_category: None,
+                    athletes: vec![],
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn sorts_movements_by_declared_order() {
+        let mut canonical = unsorted();
+        normalize(&mut canonical);
+
+        let names: Vec<_> = canonical.movements.iter().map(|m| &m.name).collect();
+        assert_eq!(names, vec!["Muscle-up", "Squat"]);
+    }
+
+    #[test]
+    fn sorts_categories_and_athletes_by_name() {
+        let mut canonical = unsorted();
+        normalize(&mut canonical);
+
+        let categories: Vec<_> = canonical.categories.iter().map(|c| &c.name).collect();
+        assert_eq!(categories, vec!["M-80", "M-87"]);
+
+        let athletes: Vec<_> = canonical.categories[1]
+            .athletes
+            .iter()
+            .map(|a| a.last_name.as_str())
+            .collect();
+        assert_eq!(athletes, vec!["Alpha", "Zulu"]);
+    }
+
+    #[test]
+    fn sorts_lifts_by_movement_order_and_attempts_by_number() {
+        let mut canonical = unsorted();
+        normalize(&mut canonical);
+
+        let athlete = &canonical.categories[1].athletes[0];
+        let lifts: Vec<_> = athlete.lifts.iter().map(|l| l.movement.as_str()).collect();
+        assert_eq!(lifts, vec!["Muscle-up", "Squat"]);
+
+        let numbers: Vec<_> = athlete.lifts[0]
+            .attempts
+            .iter()
+            .map(|a| a.attempt_number)
+            .collect();
+        assert_eq!(numbers, vec![1, 3]);
+    }
+
+    #[test]
+    fn strips_trailing_zeros_so_diffs_stay_stable() {
+        let mut canonical = unsorted();
+        normalize(&mut canonical);
+
+        let rendered = to_string(&canonical).unwrap();
+        assert!(rendered.contains("\"87\""), "{rendered}");
+        assert!(rendered.contains("\"78.5\""), "{rendered}");
+        assert!(!rendered.contains("100.00"), "{rendered}");
+    }
+
+    #[test]
+    fn normalizing_twice_changes_nothing() {
+        let mut once = unsorted();
+        normalize(&mut once);
+        let first = to_string(&once).unwrap();
+
+        let mut twice: CanonicalFormat = serde_json::from_str(&first).unwrap();
+        normalize(&mut twice);
+        let second = to_string(&twice).unwrap();
+
+        assert_eq!(first, second);
+    }
+}

--- a/backend/crates/osl_importer/src/canonical/mod.rs
+++ b/backend/crates/osl_importer/src/canonical/mod.rs
@@ -1,3 +1,4 @@
+pub mod format;
 pub mod models;
 pub mod transformer;
 pub mod validator;

--- a/backend/imports/annecy-4-lift-2025/2026-05-22T11-15-23_annecy-4-lift-2025-dimanche-matin-39_liftcontrol.json
+++ b/backend/imports/annecy-4-lift-2025/2026-05-22T11-15-23_annecy-4-lift-2025-dimanche-matin-39_liftcontrol.json
@@ -51,97 +51,6 @@
       "is_open_category": true,
       "athletes": [
         {
-          "first_name": "Timothée",
-          "last_name": "MERANDON",
-          "country": "FR",
-          "nationality": "French",
-          "bodyweight": "88.7",
-          "status": "competed",
-          "lifts": [
-            {
-              "movement": "Muscle-up",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "12.5",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "16.25",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "20",
-                  "is_successful": false,
-                  "judge_note": "[Autre]"
-                }
-              ]
-            },
-            {
-              "movement": "Pull-up",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "55",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "62.5",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "68.75",
-                  "is_successful": true
-                }
-              ]
-            },
-            {
-              "movement": "Dips",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "115",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "122.5",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "130",
-                  "is_successful": true
-                }
-              ]
-            },
-            {
-              "movement": "Squat",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "190",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "202.5",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "215",
-                  "is_successful": true
-                }
-              ]
-            }
-          ]
-        },
-        {
           "first_name": "Tom",
           "last_name": "Berthier",
           "country": "FR",
@@ -325,11 +234,11 @@
           ]
         },
         {
-          "first_name": "Loïck",
-          "last_name": "PIPOLO",
+          "first_name": "Aghiles",
+          "last_name": "HAMITI",
           "country": "FR",
           "nationality": "French",
-          "bodyweight": "92.1",
+          "bodyweight": "94.7",
           "status": "competed",
           "lifts": [
             {
@@ -357,17 +266,110 @@
               "attempts": [
                 {
                   "attempt_number": 1,
-                  "weight": "67.5",
+                  "weight": "66.25",
                   "is_successful": true
                 },
                 {
                   "attempt_number": 2,
-                  "weight": "75",
+                  "weight": "73.75",
                   "is_successful": true
                 },
                 {
                   "attempt_number": 3,
-                  "weight": "80",
+                  "weight": "76.25",
+                  "is_successful": false,
+                  "judge_note": "Passage du menton"
+                }
+              ]
+            },
+            {
+              "movement": "Dips",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "132.5",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "145",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "147.5",
+                  "is_successful": false,
+                  "judge_note": "[Autre]"
+                }
+              ]
+            },
+            {
+              "movement": "Squat",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "225",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "235",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "242.5",
+                  "is_successful": true
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "first_name": "Timothée",
+          "last_name": "MERANDON",
+          "country": "FR",
+          "nationality": "French",
+          "bodyweight": "88.7",
+          "status": "competed",
+          "lifts": [
+            {
+              "movement": "Muscle-up",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "12.5",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "16.25",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "20",
+                  "is_successful": false,
+                  "judge_note": "[Autre]"
+                }
+              ]
+            },
+            {
+              "movement": "Pull-up",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "55",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "62.5",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "68.75",
                   "is_successful": true
                 }
               ]
@@ -377,17 +379,17 @@
               "attempts": [
                 {
                   "attempt_number": 1,
-                  "weight": "110",
+                  "weight": "115",
                   "is_successful": true
                 },
                 {
                   "attempt_number": 2,
-                  "weight": "120",
+                  "weight": "122.5",
                   "is_successful": true
                 },
                 {
                   "attempt_number": 3,
-                  "weight": "127.5",
+                  "weight": "130",
                   "is_successful": true
                 }
               ]
@@ -397,19 +399,202 @@
               "attempts": [
                 {
                   "attempt_number": 1,
-                  "weight": "162.5",
+                  "weight": "190",
                   "is_successful": true
                 },
                 {
                   "attempt_number": 2,
-                  "weight": "175",
+                  "weight": "202.5",
                   "is_successful": true
                 },
                 {
                   "attempt_number": 3,
-                  "weight": "185",
+                  "weight": "215",
+                  "is_successful": true
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "first_name": "Gwendal",
+          "last_name": "NADIYA",
+          "country": "FR",
+          "nationality": "French",
+          "bodyweight": "88.8",
+          "status": "competed",
+          "lifts": [
+            {
+              "movement": "Muscle-up",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "15",
+                  "is_successful": true,
+                  "judge_note": "Flexion de genoux"
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "15",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "22.5",
+                  "is_successful": true,
+                  "judge_note": "Flexion de genoux"
+                }
+              ]
+            },
+            {
+              "movement": "Pull-up",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "65",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "72.5",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "77.5",
+                  "is_successful": true
+                }
+              ]
+            },
+            {
+              "movement": "Dips",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "120",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "127.5",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "135",
                   "is_successful": false,
                   "judge_note": "[Autre]"
+                }
+              ]
+            },
+            {
+              "movement": "Squat",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "175",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "190",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "200",
+                  "is_successful": false,
+                  "judge_note": "[Autre]"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "first_name": "Adrien",
+          "last_name": "PELFRESNE",
+          "country": "FR",
+          "nationality": "French",
+          "bodyweight": "93.8",
+          "status": "competed",
+          "lifts": [
+            {
+              "movement": "Muscle-up",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "5",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "7.5",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "10",
+                  "is_successful": true
+                }
+              ]
+            },
+            {
+              "movement": "Pull-up",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "50",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "55",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "61.25",
+                  "is_successful": true
+                }
+              ]
+            },
+            {
+              "movement": "Dips",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "92.5",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "102.5",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "110",
+                  "is_successful": true
+                }
+              ]
+            },
+            {
+              "movement": "Squat",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "152.5",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "162.5",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "175",
+                  "is_successful": true
                 }
               ]
             }
@@ -510,11 +695,11 @@
           ]
         },
         {
-          "first_name": "Adrien",
-          "last_name": "PELFRESNE",
+          "first_name": "Loïck",
+          "last_name": "PIPOLO",
           "country": "FR",
           "nationality": "French",
-          "bodyweight": "93.8",
+          "bodyweight": "92.1",
           "status": "competed",
           "lifts": [
             {
@@ -522,17 +707,17 @@
               "attempts": [
                 {
                   "attempt_number": 1,
-                  "weight": "5",
+                  "weight": "20",
                   "is_successful": true
                 },
                 {
                   "attempt_number": 2,
-                  "weight": "7.5",
+                  "weight": "25",
                   "is_successful": true
                 },
                 {
                   "attempt_number": 3,
-                  "weight": "10",
+                  "weight": "30",
                   "is_successful": true
                 }
               ]
@@ -542,17 +727,17 @@
               "attempts": [
                 {
                   "attempt_number": 1,
-                  "weight": "50",
+                  "weight": "67.5",
                   "is_successful": true
                 },
                 {
                   "attempt_number": 2,
-                  "weight": "55",
+                  "weight": "75",
                   "is_successful": true
                 },
                 {
                   "attempt_number": 3,
-                  "weight": "61.25",
+                  "weight": "80",
                   "is_successful": true
                 }
               ]
@@ -562,17 +747,17 @@
               "attempts": [
                 {
                   "attempt_number": 1,
-                  "weight": "92.5",
+                  "weight": "110",
                   "is_successful": true
                 },
                 {
                   "attempt_number": 2,
-                  "weight": "102.5",
+                  "weight": "120",
                   "is_successful": true
                 },
                 {
                   "attempt_number": 3,
-                  "weight": "110",
+                  "weight": "127.5",
                   "is_successful": true
                 }
               ]
@@ -582,18 +767,19 @@
               "attempts": [
                 {
                   "attempt_number": 1,
-                  "weight": "152.5",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
                   "weight": "162.5",
                   "is_successful": true
                 },
                 {
-                  "attempt_number": 3,
+                  "attempt_number": 2,
                   "weight": "175",
                   "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "185",
+                  "is_successful": false,
+                  "judge_note": "[Autre]"
                 }
               ]
             }
@@ -691,192 +877,6 @@
               ]
             }
           ]
-        },
-        {
-          "first_name": "Aghiles",
-          "last_name": "HAMITI",
-          "country": "FR",
-          "nationality": "French",
-          "bodyweight": "94.7",
-          "status": "competed",
-          "lifts": [
-            {
-              "movement": "Muscle-up",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "20",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "25",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "30",
-                  "is_successful": true
-                }
-              ]
-            },
-            {
-              "movement": "Pull-up",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "66.25",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "73.75",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "76.25",
-                  "is_successful": false,
-                  "judge_note": "Passage du menton"
-                }
-              ]
-            },
-            {
-              "movement": "Dips",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "132.5",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "145",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "147.5",
-                  "is_successful": false,
-                  "judge_note": "[Autre]"
-                }
-              ]
-            },
-            {
-              "movement": "Squat",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "225",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "235",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "242.5",
-                  "is_successful": true
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "first_name": "Gwendal",
-          "last_name": "NADIYA",
-          "country": "FR",
-          "nationality": "French",
-          "bodyweight": "88.8",
-          "status": "competed",
-          "lifts": [
-            {
-              "movement": "Muscle-up",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "15",
-                  "is_successful": true,
-                  "judge_note": "Flexion de genoux"
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "15",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "22.5",
-                  "is_successful": true,
-                  "judge_note": "Flexion de genoux"
-                }
-              ]
-            },
-            {
-              "movement": "Pull-up",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "65",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "72.5",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "77.5",
-                  "is_successful": true
-                }
-              ]
-            },
-            {
-              "movement": "Dips",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "120",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "127.5",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "135",
-                  "is_successful": false,
-                  "judge_note": "[Autre]"
-                }
-              ]
-            },
-            {
-              "movement": "Squat",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "175",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "190",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "200",
-                  "is_successful": false,
-                  "judge_note": "[Autre]"
-                }
-              ]
-            }
-          ]
         }
       ]
     },
@@ -886,11 +886,11 @@
       "weight_class_max": "80",
       "athletes": [
         {
-          "first_name": "Gregory",
-          "last_name": "COSTE",
+          "first_name": "Nassim",
+          "last_name": "AKEB",
           "country": "FR",
           "nationality": "French",
-          "bodyweight": "78.4",
+          "bodyweight": "76.2",
           "status": "competed",
           "lifts": [
             {
@@ -898,110 +898,17 @@
               "attempts": [
                 {
                   "attempt_number": 1,
-                  "weight": "15",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "20",
-                  "is_successful": false,
-                  "judge_note": "[Autre]"
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "20",
-                  "is_successful": true
-                }
-              ]
-            },
-            {
-              "movement": "Pull-up",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "52.5",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "57.5",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "62.5",
-                  "is_successful": false,
-                  "judge_note": "Non-respect des ordres"
-                }
-              ]
-            },
-            {
-              "movement": "Dips",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "95",
-                  "is_successful": false,
-                  "judge_note": "[Autre]"
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "102.5",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "110",
-                  "is_successful": true
-                }
-              ]
-            },
-            {
-              "movement": "Squat",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "205",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "215",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "230",
-                  "is_successful": true
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "first_name": "Gaëtan",
-          "last_name": "Orru",
-          "country": "FR",
-          "nationality": "French",
-          "bodyweight": "74.9",
-          "status": "competed",
-          "lifts": [
-            {
-              "movement": "Muscle-up",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "20",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
                   "weight": "25",
                   "is_successful": true
                 },
                 {
+                  "attempt_number": 2,
+                  "weight": "30",
+                  "is_successful": true
+                },
+                {
                   "attempt_number": 3,
-                  "weight": "27.5",
+                  "weight": "31.25",
                   "is_successful": false,
                   "judge_note": "[Autre]"
                 }
@@ -1012,115 +919,18 @@
               "attempts": [
                 {
                   "attempt_number": 1,
-                  "weight": "62.5",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "68.25",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "70",
-                  "is_successful": false,
-                  "judge_note": "Passage du menton"
-                }
-              ]
-            },
-            {
-              "movement": "Dips",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "92.5",
-                  "is_successful": false,
-                  "judge_note": "Amplitude hanches"
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "100",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "103.75",
-                  "is_successful": true
-                }
-              ]
-            },
-            {
-              "movement": "Squat",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "177.5",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "187.5",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "200",
-                  "is_successful": false,
-                  "judge_note": "Barre tombée"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "first_name": "Loyan",
-          "last_name": "LANDES",
-          "country": "FR",
-          "nationality": "French",
-          "bodyweight": "76.1",
-          "status": "competed",
-          "lifts": [
-            {
-              "movement": "Muscle-up",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "12.5",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "15",
-                  "is_successful": false,
-                  "judge_note": "Utilisation d’un False Grip"
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "15",
-                  "is_successful": true,
-                  "judge_note": "Utilisation d’un False Grip"
-                }
-              ]
-            },
-            {
-              "movement": "Pull-up",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "50",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "55",
-                  "is_successful": true,
-                  "judge_note": "[Autre]"
-                },
-                {
-                  "attempt_number": 3,
                   "weight": "57.5",
-                  "is_successful": true,
-                  "judge_note": "Passage du menton"
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "65",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "71.25",
+                  "is_successful": true
                 }
               ]
             },
@@ -1129,109 +939,18 @@
               "attempts": [
                 {
                   "attempt_number": 1,
-                  "weight": "70",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "75",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
                   "weight": "82.5",
                   "is_successful": true
-                }
-              ]
-            },
-            {
-              "movement": "Squat",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "100",
-                  "is_successful": true
                 },
                 {
                   "attempt_number": 2,
-                  "weight": "110",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "120",
-                  "is_successful": true
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "first_name": "Richard",
-          "last_name": "Fanfano",
-          "country": "FR",
-          "nationality": "French",
-          "bodyweight": "75.6",
-          "status": "competed",
-          "lifts": [
-            {
-              "movement": "Muscle-up",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "16.25",
+                  "weight": "92.5",
                   "is_successful": false,
-                  "judge_note": "Cassage des hanches"
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "21.25",
-                  "is_successful": true
+                  "judge_note": "[Autre]"
                 },
                 {
                   "attempt_number": 3,
-                  "weight": "25",
-                  "is_successful": true
-                }
-              ]
-            },
-            {
-              "movement": "Pull-up",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "57.5",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "66.25",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "72.5",
-                  "is_successful": false,
-                  "judge_note": "Passage du menton"
-                }
-              ]
-            },
-            {
-              "movement": "Dips",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "112.5",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "115",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "117.5",
+                  "weight": "92.5",
                   "is_successful": false,
                   "judge_note": "[Autre]"
                 }
@@ -1242,202 +961,19 @@
               "attempts": [
                 {
                   "attempt_number": 1,
-                  "weight": "155",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "167.5",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "170",
-                  "is_successful": true
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "first_name": "Anaël",
-          "last_name": "GALOPIN",
-          "country": "FR",
-          "nationality": "French",
-          "bodyweight": "79.2",
-          "status": "competed",
-          "lifts": [
-            {
-              "movement": "Muscle-up",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "10",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "10",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "15",
-                  "is_successful": true
-                }
-              ]
-            },
-            {
-              "movement": "Pull-up",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "50",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "60",
-                  "is_successful": false,
-                  "judge_note": "Non-respect des ordres"
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "67.5",
-                  "is_successful": true
-                }
-              ]
-            },
-            {
-              "movement": "Dips",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "85",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "95",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "100",
-                  "is_successful": false,
-                  "judge_note": "[Autre]"
-                }
-              ]
-            },
-            {
-              "movement": "Squat",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "187.5",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
                   "weight": "197.5",
                   "is_successful": true
                 },
                 {
-                  "attempt_number": 3,
-                  "weight": "200",
-                  "is_successful": true,
-                  "judge_note": "[Autre]"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "first_name": "Ilyes",
-          "last_name": "PELLETIER",
-          "country": "FR",
-          "nationality": "French",
-          "bodyweight": "75.5",
-          "status": "competed",
-          "lifts": [
-            {
-              "movement": "Muscle-up",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "15",
-                  "is_successful": true
-                },
-                {
                   "attempt_number": 2,
-                  "weight": "17.5",
+                  "weight": "207.5",
                   "is_successful": true
                 },
                 {
                   "attempt_number": 3,
-                  "weight": "20",
-                  "is_successful": true
-                }
-              ]
-            },
-            {
-              "movement": "Pull-up",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "50",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "55",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "60",
+                  "weight": "217.5",
                   "is_successful": false,
-                  "judge_note": "Passage du menton"
-                }
-              ]
-            },
-            {
-              "movement": "Dips",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "95",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "103.75",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "107.5",
-                  "is_successful": true
-                }
-              ]
-            },
-            {
-              "movement": "Squat",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "165",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "175",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "185",
-                  "is_successful": true
+                  "judge_note": "Barre tombée"
                 }
               ]
             }
@@ -1529,193 +1065,6 @@
                   "attempt_number": 3,
                   "weight": "162.5",
                   "is_successful": true
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "first_name": "Hugo",
-          "last_name": "MEUNIER",
-          "country": "FR",
-          "nationality": "French",
-          "bodyweight": "74.6",
-          "status": "competed",
-          "lifts": [
-            {
-              "movement": "Muscle-up",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "5",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "8.75",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "10",
-                  "is_successful": true
-                }
-              ]
-            },
-            {
-              "movement": "Pull-up",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "42.5",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "50",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "53.75",
-                  "is_successful": true
-                }
-              ]
-            },
-            {
-              "movement": "Dips",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "75",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "82.5",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "90",
-                  "is_successful": false,
-                  "judge_note": "[Autre]"
-                }
-              ]
-            },
-            {
-              "movement": "Squat",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "135",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "147.5",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "160",
-                  "is_successful": true
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "first_name": "François",
-          "last_name": "DELAVEAU",
-          "country": "FR",
-          "nationality": "French",
-          "bodyweight": "76.2",
-          "status": "competed",
-          "lifts": [
-            {
-              "movement": "Muscle-up",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "5",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "10",
-                  "is_successful": false,
-                  "judge_note": "[Autre]"
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "10",
-                  "is_successful": false,
-                  "judge_note": "[Autre]"
-                }
-              ]
-            },
-            {
-              "movement": "Pull-up",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "50",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "55",
-                  "is_successful": false,
-                  "judge_note": "Non-respect des ordres"
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "56.25",
-                  "is_successful": true
-                }
-              ]
-            },
-            {
-              "movement": "Dips",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "82.5",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "86.25",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "90",
-                  "is_successful": false,
-                  "judge_note": "[Autre]"
-                }
-              ]
-            },
-            {
-              "movement": "Squat",
-              "attempts": [
-                {
-                  "attempt_number": 1,
-                  "weight": "162.5",
-                  "is_successful": true
-                },
-                {
-                  "attempt_number": 2,
-                  "weight": "172.5",
-                  "is_successful": false,
-                  "judge_note": "Non-respect des ordres"
-                },
-                {
-                  "attempt_number": 3,
-                  "weight": "180",
-                  "is_successful": false,
-                  "judge_note": "[Autre]"
                 }
               ]
             }
@@ -1908,8 +1257,196 @@
           ]
         },
         {
-          "first_name": "Nassim",
-          "last_name": "AKEB",
+          "first_name": "Gregory",
+          "last_name": "COSTE",
+          "country": "FR",
+          "nationality": "French",
+          "bodyweight": "78.4",
+          "status": "competed",
+          "lifts": [
+            {
+              "movement": "Muscle-up",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "15",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "20",
+                  "is_successful": false,
+                  "judge_note": "[Autre]"
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "20",
+                  "is_successful": true
+                }
+              ]
+            },
+            {
+              "movement": "Pull-up",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "52.5",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "57.5",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "62.5",
+                  "is_successful": false,
+                  "judge_note": "Non-respect des ordres"
+                }
+              ]
+            },
+            {
+              "movement": "Dips",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "95",
+                  "is_successful": false,
+                  "judge_note": "[Autre]"
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "102.5",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "110",
+                  "is_successful": true
+                }
+              ]
+            },
+            {
+              "movement": "Squat",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "205",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "215",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "230",
+                  "is_successful": true
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "first_name": "Thibault",
+          "last_name": "DAUSQUE",
+          "country": "FR",
+          "nationality": "French",
+          "bodyweight": "79.9",
+          "status": "competed",
+          "lifts": [
+            {
+              "movement": "Muscle-up",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "20",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "25",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "28.5",
+                  "is_successful": false,
+                  "judge_note": "Positionnement non-conforme des poids"
+                }
+              ]
+            },
+            {
+              "movement": "Pull-up",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "65",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "71.25",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "75",
+                  "is_successful": true
+                }
+              ]
+            },
+            {
+              "movement": "Dips",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "95",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "100",
+                  "is_successful": false,
+                  "judge_note": "Amplitude hanches"
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "102.5",
+                  "is_successful": false,
+                  "judge_note": "[Autre]"
+                }
+              ]
+            },
+            {
+              "movement": "Squat",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "155",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "0.02",
+                  "is_successful": false,
+                  "judge_note": "[Autre]"
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "0.02",
+                  "is_successful": false,
+                  "judge_note": "[Autre]"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "first_name": "François",
+          "last_name": "DELAVEAU",
           "country": "FR",
           "nationality": "French",
           "bodyweight": "76.2",
@@ -1920,17 +1457,18 @@
               "attempts": [
                 {
                   "attempt_number": 1,
-                  "weight": "25",
+                  "weight": "5",
                   "is_successful": true
                 },
                 {
                   "attempt_number": 2,
-                  "weight": "30",
-                  "is_successful": true
+                  "weight": "10",
+                  "is_successful": false,
+                  "judge_note": "[Autre]"
                 },
                 {
                   "attempt_number": 3,
-                  "weight": "31.25",
+                  "weight": "10",
                   "is_successful": false,
                   "judge_note": "[Autre]"
                 }
@@ -1941,17 +1479,18 @@
               "attempts": [
                 {
                   "attempt_number": 1,
-                  "weight": "57.5",
+                  "weight": "50",
                   "is_successful": true
                 },
                 {
                   "attempt_number": 2,
-                  "weight": "65",
-                  "is_successful": true
+                  "weight": "55",
+                  "is_successful": false,
+                  "judge_note": "Non-respect des ordres"
                 },
                 {
                   "attempt_number": 3,
-                  "weight": "71.25",
+                  "weight": "56.25",
                   "is_successful": true
                 }
               ]
@@ -1966,13 +1505,12 @@
                 },
                 {
                   "attempt_number": 2,
-                  "weight": "92.5",
-                  "is_successful": false,
-                  "judge_note": "[Autre]"
+                  "weight": "86.25",
+                  "is_successful": true
                 },
                 {
                   "attempt_number": 3,
-                  "weight": "92.5",
+                  "weight": "90",
                   "is_successful": false,
                   "judge_note": "[Autre]"
                 }
@@ -1983,30 +1521,31 @@
               "attempts": [
                 {
                   "attempt_number": 1,
-                  "weight": "197.5",
+                  "weight": "162.5",
                   "is_successful": true
                 },
                 {
                   "attempt_number": 2,
-                  "weight": "207.5",
-                  "is_successful": true
+                  "weight": "172.5",
+                  "is_successful": false,
+                  "judge_note": "Non-respect des ordres"
                 },
                 {
                   "attempt_number": 3,
-                  "weight": "217.5",
+                  "weight": "180",
                   "is_successful": false,
-                  "judge_note": "Barre tombée"
+                  "judge_note": "[Autre]"
                 }
               ]
             }
           ]
         },
         {
-          "first_name": "Alexandre",
-          "last_name": "Thenoz",
+          "first_name": "Richard",
+          "last_name": "Fanfano",
           "country": "FR",
           "nationality": "French",
-          "bodyweight": "78.2",
+          "bodyweight": "75.6",
           "status": "competed",
           "lifts": [
             {
@@ -2014,17 +1553,18 @@
               "attempts": [
                 {
                   "attempt_number": 1,
-                  "weight": "17.5",
-                  "is_successful": true
+                  "weight": "16.25",
+                  "is_successful": false,
+                  "judge_note": "Cassage des hanches"
                 },
                 {
                   "attempt_number": 2,
-                  "weight": "20",
+                  "weight": "21.25",
                   "is_successful": true
                 },
                 {
                   "attempt_number": 3,
-                  "weight": "22.5",
+                  "weight": "25",
                   "is_successful": true
                 }
               ]
@@ -2034,17 +1574,110 @@
               "attempts": [
                 {
                   "attempt_number": 1,
-                  "weight": "65",
+                  "weight": "57.5",
                   "is_successful": true
                 },
                 {
                   "attempt_number": 2,
-                  "weight": "71.25",
+                  "weight": "66.25",
                   "is_successful": true
                 },
                 {
                   "attempt_number": 3,
-                  "weight": "76.25",
+                  "weight": "72.5",
+                  "is_successful": false,
+                  "judge_note": "Passage du menton"
+                }
+              ]
+            },
+            {
+              "movement": "Dips",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "112.5",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "115",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "117.5",
+                  "is_successful": false,
+                  "judge_note": "[Autre]"
+                }
+              ]
+            },
+            {
+              "movement": "Squat",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "155",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "167.5",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "170",
+                  "is_successful": true
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "first_name": "Anaël",
+          "last_name": "GALOPIN",
+          "country": "FR",
+          "nationality": "French",
+          "bodyweight": "79.2",
+          "status": "competed",
+          "lifts": [
+            {
+              "movement": "Muscle-up",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "10",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "10",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "15",
+                  "is_successful": true
+                }
+              ]
+            },
+            {
+              "movement": "Pull-up",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "50",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "60",
+                  "is_successful": false,
+                  "judge_note": "Non-respect des ordres"
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "67.5",
                   "is_successful": true
                 }
               ]
@@ -2054,17 +1687,113 @@
               "attempts": [
                 {
                   "attempt_number": 1,
-                  "weight": "87.5",
+                  "weight": "85",
                   "is_successful": true
                 },
                 {
                   "attempt_number": 2,
-                  "weight": "96.25",
+                  "weight": "95",
                   "is_successful": true
                 },
                 {
                   "attempt_number": 3,
-                  "weight": "102.5",
+                  "weight": "100",
+                  "is_successful": false,
+                  "judge_note": "[Autre]"
+                }
+              ]
+            },
+            {
+              "movement": "Squat",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "187.5",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "197.5",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "200",
+                  "is_successful": true,
+                  "judge_note": "[Autre]"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "first_name": "Loyan",
+          "last_name": "LANDES",
+          "country": "FR",
+          "nationality": "French",
+          "bodyweight": "76.1",
+          "status": "competed",
+          "lifts": [
+            {
+              "movement": "Muscle-up",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "12.5",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "15",
+                  "is_successful": false,
+                  "judge_note": "Utilisation d’un False Grip"
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "15",
+                  "is_successful": true,
+                  "judge_note": "Utilisation d’un False Grip"
+                }
+              ]
+            },
+            {
+              "movement": "Pull-up",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "50",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "55",
+                  "is_successful": true,
+                  "judge_note": "[Autre]"
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "57.5",
+                  "is_successful": true,
+                  "judge_note": "Passage du menton"
+                }
+              ]
+            },
+            {
+              "movement": "Dips",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "70",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "75",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "82.5",
                   "is_successful": true
                 }
               ]
@@ -2074,19 +1803,18 @@
               "attempts": [
                 {
                   "attempt_number": 1,
-                  "weight": "160",
+                  "weight": "100",
                   "is_successful": true
                 },
                 {
                   "attempt_number": 2,
-                  "weight": "172.5",
+                  "weight": "110",
                   "is_successful": true
                 },
                 {
                   "attempt_number": 3,
-                  "weight": "182.5",
-                  "is_successful": false,
-                  "judge_note": "[Autre]"
+                  "weight": "120",
+                  "is_successful": true
                 }
               ]
             }
@@ -2186,11 +1914,102 @@
           ]
         },
         {
-          "first_name": "Thibault",
-          "last_name": "DAUSQUE",
+          "first_name": "Hugo",
+          "last_name": "MEUNIER",
           "country": "FR",
           "nationality": "French",
-          "bodyweight": "79.9",
+          "bodyweight": "74.6",
+          "status": "competed",
+          "lifts": [
+            {
+              "movement": "Muscle-up",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "5",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "8.75",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "10",
+                  "is_successful": true
+                }
+              ]
+            },
+            {
+              "movement": "Pull-up",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "42.5",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "50",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "53.75",
+                  "is_successful": true
+                }
+              ]
+            },
+            {
+              "movement": "Dips",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "75",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "82.5",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "90",
+                  "is_successful": false,
+                  "judge_note": "[Autre]"
+                }
+              ]
+            },
+            {
+              "movement": "Squat",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "135",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "147.5",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "160",
+                  "is_successful": true
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "first_name": "Gaëtan",
+          "last_name": "Orru",
+          "country": "FR",
+          "nationality": "French",
+          "bodyweight": "74.9",
           "status": "competed",
           "lifts": [
             {
@@ -2208,9 +2027,193 @@
                 },
                 {
                   "attempt_number": 3,
-                  "weight": "28.5",
+                  "weight": "27.5",
                   "is_successful": false,
-                  "judge_note": "Positionnement non-conforme des poids"
+                  "judge_note": "[Autre]"
+                }
+              ]
+            },
+            {
+              "movement": "Pull-up",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "62.5",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "68.25",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "70",
+                  "is_successful": false,
+                  "judge_note": "Passage du menton"
+                }
+              ]
+            },
+            {
+              "movement": "Dips",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "92.5",
+                  "is_successful": false,
+                  "judge_note": "Amplitude hanches"
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "100",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "103.75",
+                  "is_successful": true
+                }
+              ]
+            },
+            {
+              "movement": "Squat",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "177.5",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "187.5",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "200",
+                  "is_successful": false,
+                  "judge_note": "Barre tombée"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "first_name": "Ilyes",
+          "last_name": "PELLETIER",
+          "country": "FR",
+          "nationality": "French",
+          "bodyweight": "75.5",
+          "status": "competed",
+          "lifts": [
+            {
+              "movement": "Muscle-up",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "15",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "17.5",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "20",
+                  "is_successful": true
+                }
+              ]
+            },
+            {
+              "movement": "Pull-up",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "50",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "55",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "60",
+                  "is_successful": false,
+                  "judge_note": "Passage du menton"
+                }
+              ]
+            },
+            {
+              "movement": "Dips",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "95",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "103.75",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "107.5",
+                  "is_successful": true
+                }
+              ]
+            },
+            {
+              "movement": "Squat",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "165",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "175",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "185",
+                  "is_successful": true
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "first_name": "Alexandre",
+          "last_name": "Thenoz",
+          "country": "FR",
+          "nationality": "French",
+          "bodyweight": "78.2",
+          "status": "competed",
+          "lifts": [
+            {
+              "movement": "Muscle-up",
+              "attempts": [
+                {
+                  "attempt_number": 1,
+                  "weight": "17.5",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 2,
+                  "weight": "20",
+                  "is_successful": true
+                },
+                {
+                  "attempt_number": 3,
+                  "weight": "22.5",
+                  "is_successful": true
                 }
               ]
             },
@@ -2229,7 +2232,7 @@
                 },
                 {
                   "attempt_number": 3,
-                  "weight": "75",
+                  "weight": "76.25",
                   "is_successful": true
                 }
               ]
@@ -2239,20 +2242,18 @@
               "attempts": [
                 {
                   "attempt_number": 1,
-                  "weight": "95",
+                  "weight": "87.5",
                   "is_successful": true
                 },
                 {
                   "attempt_number": 2,
-                  "weight": "100",
-                  "is_successful": false,
-                  "judge_note": "Amplitude hanches"
+                  "weight": "96.25",
+                  "is_successful": true
                 },
                 {
                   "attempt_number": 3,
                   "weight": "102.5",
-                  "is_successful": false,
-                  "judge_note": "[Autre]"
+                  "is_successful": true
                 }
               ]
             },
@@ -2261,18 +2262,17 @@
               "attempts": [
                 {
                   "attempt_number": 1,
-                  "weight": "155",
+                  "weight": "160",
                   "is_successful": true
                 },
                 {
                   "attempt_number": 2,
-                  "weight": "0.02",
-                  "is_successful": false,
-                  "judge_note": "[Autre]"
+                  "weight": "172.5",
+                  "is_successful": true
                 },
                 {
                   "attempt_number": 3,
-                  "weight": "0.02",
+                  "weight": "182.5",
                   "is_successful": false,
                   "judge_note": "[Autre]"
                 }


### PR DESCRIPTION
Canonical files are built up over many edits and reviewed as git diffs. Without a fixed shape, a change adding a few athletes rewrites the whole file and stops being reviewable.

fmt sorts and normalises decimals, --check enforces it in CI, which also validates every file now.