### PR TITLE
feat(importer)!: canonical format 1.2.0

### DIFF
--- a/.claude/skills/extract-competition/SKILL.md
+++ b/.claude/skills/extract-competition/SKILL.md
@@ -62,13 +62,13 @@ them loses real data.
 
 ## Format
 
-`format_version` is `1.1.0`. Required fields have no marker; `?` means
+`format_version` is `1.2.0`. Required fields have no marker; `?` means
 optional and should be omitted when unknown.
 
 ```jsonc
 {
+  "format_version": "1.2.0",
   "source": {
-    "format_version": "1.1.0",
     "type": "html",              // api | html | pdf | csv | image | manual
     "url": "https://...",        // ?
     "extracted_at": "2026-08-10T10:00:00Z",
@@ -88,7 +88,7 @@ optional and should be omitted when unknown.
     "end_date": "2025-11-02",
     "venue": "Oski Crossfit",    // ?
     "city": "Annecy",            // ?
-    "country": "France",
+    "country": "FR",             // ISO 3166-1 alpha-2
     "number_of_judges": 3,       // ? must be 1 or 3
     "status": "completed"        // ? draft|upcoming|live|completed|cancelled
   },
@@ -98,17 +98,17 @@ optional and should be omitted when unknown.
   "categories": [
     {
       "name": "Catégorie -80",
-      "gender": "M",             // M or F only
-      "weight_class_slug": "M-80",   // ? see list below
-      "weight_class_max": "80",      // ? decimal as a string
-      "is_open_category": true,      // ? for +87 style categories
+      "gender": "M",             // M, F or MX
+      "weight_class_slug": "M-80",   // ? standard class, see list below
+      "weight_class_max": "80",      // ? non standard class only
+      "is_open_category": true,      // ? non standard class only
       "athletes": [
         {
           "first_name": "Timothée",
           "last_name": "MERANDON",
           "gender": "M",         // ?
-          "country": "FR",
-          "nationality": "French",   // ?
+          "country": "FR",           // country represented, ISO alpha-2
+          "nationality": "FR",       // ? citizenship if it differs
           "team": "...",             // ?
           "bodyweight": "88.7",      // ?
           "status": "competed",      // competed | disqualified
@@ -134,15 +134,21 @@ optional and should be omitted when unknown.
 ```
 
 `weight_class_slug` is one of: `F-52` `F-57` `F-63` `F-70` `F+70` `M-66`
-`M-73` `M-80` `M-87` `M-94` `M-101` `M+101`.
+`M-73` `M-80` `M-87` `M-94` `M-101` `M+101`. It already carries the bounds,
+so a category using it must not also set `weight_class_max` or
+`is_open_category`. Use those two only for a class outside the standard
+ladder, such as a local meet running -75.
 
-Weights and bodyweights are JSON **strings**, not numbers.
+Weights and bodyweights are JSON **strings**, not numbers. Countries are ISO
+3166-1 alpha-2, so `FR` and never `France` or `FRA`.
 
 ### What the validator rejects
 
-Wrong `format_version`, empty `extractor`, a gender that is not `M` or `F`,
-`end_date` before `start_date`, a duplicate or unnamed movement, a movement
-`order` below 1, a lift naming a movement not in `movements`, a lift with no
+Wrong `format_version`, empty `extractor`, a country that is not two letters,
+a gender outside `M` `F` `MX`, a status outside the five listed, a judge count
+other than 1 or 3, `end_date` before `start_date`, a duplicate or unnamed
+movement, a movement `order` below 1, a weight class setting both the slug and
+the raw bounds, a lift naming a movement not in `movements`, a lift with no
 attempts, an `attempt_number` outside 1 to 3, a negative weight.
 
 ### What it only warns about

--- a/backend/crates/osl_domain/src/competition_status.rs
+++ b/backend/crates/osl_domain/src/competition_status.rs
@@ -1,0 +1,45 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CompetitionStatus {
+    #[default]
+    Draft,
+    Upcoming,
+    Live,
+    Completed,
+    Cancelled,
+}
+
+impl CompetitionStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Draft => "draft",
+            Self::Upcoming => "upcoming",
+            Self::Live => "live",
+            Self::Completed => "completed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+}
+
+impl std::fmt::Display for CompetitionStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl std::str::FromStr for CompetitionStatus {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "draft" => Ok(Self::Draft),
+            "upcoming" => Ok(Self::Upcoming),
+            "live" => Ok(Self::Live),
+            "completed" => Ok(Self::Completed),
+            "cancelled" => Ok(Self::Cancelled),
+            other => Err(format!("unknown competition status: {}", other)),
+        }
+    }
+}

--- a/backend/crates/osl_domain/src/country.rs
+++ b/backend/crates/osl_domain/src/country.rs
@@ -1,0 +1,80 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// ISO 3166-1 alpha-2 country code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CountryCode([u8; 2]);
+
+impl CountryCode {
+    pub fn parse(raw: &str) -> Result<Self, String> {
+        let trimmed = raw.trim();
+        let bytes = trimmed.as_bytes();
+
+        if bytes.len() != 2 || !bytes.iter().all(|b| b.is_ascii_alphabetic()) {
+            return Err(format!(
+                "'{}' is not an ISO 3166-1 alpha-2 country code, expected two letters like FR",
+                trimmed
+            ));
+        }
+
+        Ok(Self([
+            bytes[0].to_ascii_uppercase(),
+            bytes[1].to_ascii_uppercase(),
+        ]))
+    }
+
+    pub fn as_str(&self) -> &str {
+        std::str::from_utf8(&self.0).expect("country code is ascii")
+    }
+}
+
+impl std::fmt::Display for CountryCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl std::str::FromStr for CountryCode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
+    }
+}
+
+impl Serialize for CountryCode {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for CountryCode {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(deserializer)?;
+        Self::parse(&raw).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uppercases_and_trims() {
+        assert_eq!(CountryCode::parse("  fr ").unwrap().as_str(), "FR");
+    }
+
+    #[test]
+    fn rejects_country_names_and_alpha3() {
+        for raw in ["France", "FRA", "F", ""] {
+            assert!(CountryCode::parse(raw).is_err(), "accepted {raw}");
+        }
+    }
+
+    #[test]
+    fn same_country_written_two_ways_compares_equal() {
+        assert_eq!(
+            CountryCode::parse("fr").unwrap(),
+            CountryCode::parse("FR").unwrap()
+        );
+    }
+}

--- a/backend/crates/osl_domain/src/gender.rs
+++ b/backend/crates/osl_domain/src/gender.rs
@@ -1,0 +1,40 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Gender {
+    #[serde(rename = "M")]
+    M,
+    #[serde(rename = "F")]
+    F,
+    #[serde(rename = "MX")]
+    Mx,
+}
+
+impl Gender {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::M => "M",
+            Self::F => "F",
+            Self::Mx => "MX",
+        }
+    }
+}
+
+impl std::fmt::Display for Gender {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl std::str::FromStr for Gender {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_ascii_uppercase().as_str() {
+            "M" => Ok(Self::M),
+            "F" => Ok(Self::F),
+            "MX" => Ok(Self::Mx),
+            other => Err(format!("unknown gender: {}, expected M, F or MX", other)),
+        }
+    }
+}

--- a/backend/crates/osl_domain/src/lib.rs
+++ b/backend/crates/osl_domain/src/lib.rs
@@ -1,10 +1,16 @@
 pub mod athlete_status;
+pub mod competition_status;
+pub mod country;
 pub mod error;
+pub mod gender;
 pub mod normalized_name;
 pub mod ris;
 pub mod weight_class;
 
 pub use athlete_status::AthleteStatus;
+pub use competition_status::CompetitionStatus;
+pub use country::CountryCode;
+pub use gender::Gender;
 pub use normalized_name::NormalizedAthleteName;
 pub use ris::{FormulaConstants, RisFormula};
 pub use weight_class::{WeightClass, WeightClassSlug};

--- a/backend/crates/osl_domain/src/weight_class.rs
+++ b/backend/crates/osl_domain/src/weight_class.rs
@@ -47,6 +47,25 @@ impl WeightClassSlug {
             Self::MPlus101 => "M+101",
         }
     }
+
+    pub fn bounds(&self) -> (Option<Decimal>, Option<Decimal>) {
+        let (min, max) = match self {
+            Self::F52 => (None, Some(52)),
+            Self::F57 => (Some(52), Some(57)),
+            Self::F63 => (Some(57), Some(63)),
+            Self::F70 => (Some(63), Some(70)),
+            Self::FPlus70 => (Some(70), None),
+            Self::M66 => (None, Some(66)),
+            Self::M73 => (Some(66), Some(73)),
+            Self::M80 => (Some(73), Some(80)),
+            Self::M87 => (Some(80), Some(87)),
+            Self::M94 => (Some(87), Some(94)),
+            Self::M101 => (Some(94), Some(101)),
+            Self::MPlus101 => (Some(101), None),
+        };
+
+        (min.map(Decimal::from), max.map(Decimal::from))
+    }
 }
 
 impl std::fmt::Display for WeightClassSlug {
@@ -83,4 +102,33 @@ pub struct WeightClass {
     pub gender: String,
     pub limit_kg: Option<Decimal>,
     pub is_plus: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lightest_class_has_no_lower_bound() {
+        assert_eq!(
+            WeightClassSlug::M66.bounds(),
+            (None, Some(Decimal::from(66)))
+        );
+    }
+
+    #[test]
+    fn a_middle_class_starts_where_the_one_below_ends() {
+        assert_eq!(
+            WeightClassSlug::M80.bounds(),
+            (Some(Decimal::from(73)), Some(Decimal::from(80)))
+        );
+    }
+
+    #[test]
+    fn an_open_class_has_no_upper_bound() {
+        assert_eq!(
+            WeightClassSlug::MPlus101.bounds(),
+            (Some(Decimal::from(101)), None)
+        );
+    }
 }

--- a/backend/crates/osl_importer/src/bin/import.rs
+++ b/backend/crates/osl_importer/src/bin/import.rs
@@ -163,7 +163,7 @@ async fn handle_canonical_import(
     tracing::info!(
         "Loaded competition: {} (v{})",
         canonical.competition.name,
-        canonical.source.format_version
+        canonical.format_version
     );
 
     tracing::info!("Validating canonical format...");

--- a/backend/crates/osl_importer/src/canonical/format.rs
+++ b/backend/crates/osl_importer/src/canonical/format.rs
@@ -80,7 +80,7 @@ mod tests {
         LiftData, MovementData, SourceMetadata, SourceType,
     };
     use chrono::NaiveDate;
-    use osl_domain::AthleteStatus;
+    use osl_domain::{AthleteStatus, CountryCode, Gender};
     use rust_decimal::Decimal;
     use std::str::FromStr;
 
@@ -89,7 +89,7 @@ mod tests {
             first_name: first.to_string(),
             last_name: last.to_string(),
             gender: None,
-            country: "FR".to_string(),
+            country: CountryCode::parse("FR").unwrap(),
             nationality: None,
             team: None,
             bodyweight: Some(Decimal::from_str("78.50").unwrap()),
@@ -120,8 +120,8 @@ mod tests {
 
     fn unsorted() -> CanonicalFormat {
         CanonicalFormat {
+            format_version: FORMAT_VERSION.to_string(),
             source: SourceMetadata {
-                format_version: FORMAT_VERSION.to_string(),
                 r#type: SourceType::Image,
                 url: None,
                 extracted_at: chrono::Utc::now(),
@@ -141,7 +141,7 @@ mod tests {
                 end_date: NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
                 venue: None,
                 city: None,
-                country: "FR".to_string(),
+                country: CountryCode::parse("FR").unwrap(),
                 number_of_judges: Some(3),
                 status: None,
             },
@@ -160,7 +160,7 @@ mod tests {
             categories: vec![
                 CategoryData {
                     name: "M-87".to_string(),
-                    gender: "M".to_string(),
+                    gender: Gender::M,
                     weight_class_slug: None,
                     weight_class_max: Some(Decimal::from_str("87.0").unwrap()),
                     is_open_category: None,
@@ -171,7 +171,7 @@ mod tests {
                 },
                 CategoryData {
                     name: "M-80".to_string(),
-                    gender: "M".to_string(),
+                    gender: Gender::M,
                     weight_class_slug: None,
                     weight_class_max: Some(Decimal::from(80)),
                     is_open_category: None,

--- a/backend/crates/osl_importer/src/canonical/models.rs
+++ b/backend/crates/osl_importer/src/canonical/models.rs
@@ -1,13 +1,17 @@
 use chrono::{DateTime, NaiveDate, Utc};
-use osl_domain::{AthleteStatus, WeightClassSlug};
+use osl_domain::{AthleteStatus, CompetitionStatus, CountryCode, Gender, WeightClassSlug};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
 /// Format version this build reads and writes.
-pub const FORMAT_VERSION: &str = "1.1.0";
+pub const FORMAT_VERSION: &str = "1.2.0";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CanonicalFormat {
+    /// First key of the document: a reader picks how to parse the rest from
+    /// it, so it cannot live inside a section that a later version may move.
+    pub format_version: String,
+
     pub source: SourceMetadata,
     pub competition: CompetitionData,
     pub movements: Vec<MovementData>,
@@ -16,8 +20,6 @@ pub struct CanonicalFormat {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SourceMetadata {
-    pub format_version: String,
-
     #[serde(rename = "type")]
     pub r#type: SourceType,
 
@@ -71,13 +73,13 @@ pub struct CompetitionData {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub city: Option<String>,
 
-    pub country: String,
+    pub country: CountryCode,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub number_of_judges: Option<i16>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<String>,
+    pub status: Option<CompetitionStatus>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -91,7 +93,7 @@ pub struct FederationData {
     pub abbreviation: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<String>,
+    pub country: Option<CountryCode>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -108,7 +110,7 @@ pub struct MovementData {
 pub struct CategoryData {
     pub name: String,
 
-    pub gender: String,
+    pub gender: Gender,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub weight_class_slug: Option<WeightClassSlug>,
@@ -129,12 +131,14 @@ pub struct AthleteData {
     pub last_name: String,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub gender: Option<String>,
+    pub gender: Option<Gender>,
 
-    pub country: String,
+    /// Country the athlete represented at this competition.
+    pub country: CountryCode,
 
+    /// Citizenship, when it differs from `country` and is known.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nationality: Option<String>,
+    pub nationality: Option<CountryCode>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub team: Option<String>,

--- a/backend/crates/osl_importer/src/canonical/transformer.rs
+++ b/backend/crates/osl_importer/src/canonical/transformer.rs
@@ -1,7 +1,6 @@
 use super::models::*;
 use crate::{ImporterError, Result};
 use osl_domain::NormalizedAthleteName;
-use rust_decimal::Decimal;
 use sqlx::PgPool;
 use tracing::info;
 use uuid::Uuid;
@@ -74,13 +73,13 @@ impl<'a> CanonicalTransformer<'a> {
             "#,
             competition.name,
             competition.slug,
-            competition.status.as_deref().unwrap_or("completed"),
+            competition.status.unwrap_or_default().as_str(),
             federation_id,
             competition.start_date,
             competition.end_date,
             competition.venue,
             competition.city,
-            competition.country,
+            competition.country.as_str(),
             competition.number_of_judges
         )
         .fetch_one(&mut **tx)
@@ -113,7 +112,7 @@ impl<'a> CanonicalTransformer<'a> {
             "#,
             federation.name,
             federation.abbreviation,
-            federation.country
+            federation.country.map(|c| c.as_str().to_owned())
         )
         .fetch_one(&mut **tx)
         .await
@@ -157,10 +156,12 @@ impl<'a> CanonicalTransformer<'a> {
         category: &CategoryData,
         tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     ) -> Result<Uuid> {
+        let gender = category.gender.as_str();
+
         let existing = sqlx::query_scalar!(
             r#"SELECT category_id as "category_id: Uuid" FROM categories WHERE name = $1 AND gender = $2"#,
             category.name,
-            category.gender
+            gender
         )
         .fetch_optional(&mut **tx)
         .await?;
@@ -169,6 +170,11 @@ impl<'a> CanonicalTransformer<'a> {
             return Ok(id);
         }
 
+        let (min, max) = match category.weight_class_slug.as_ref() {
+            Some(slug) => slug.bounds(),
+            None => (None, category.weight_class_max),
+        };
+
         let category_id = sqlx::query_scalar!(
             r#"
             INSERT INTO categories (name, gender, weight_class_min, weight_class_max)
@@ -176,12 +182,9 @@ impl<'a> CanonicalTransformer<'a> {
             RETURNING category_id as "category_id: Uuid"
             "#,
             category.name,
-            category.gender,
-            // The format states the upper bound only. A category's lower
-            // bound is the class below it, which needs the full ladder, so
-            // it stays null as it already was.
-            None as Option<Decimal>,
-            category.weight_class_max
+            gender,
+            min,
+            max
         )
         .fetch_one(&mut **tx)
         .await?;
@@ -241,7 +244,7 @@ impl<'a> CanonicalTransformer<'a> {
         category: &CategoryData,
         tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     ) -> Result<Uuid> {
-        let gender = athlete.gender.as_deref().unwrap_or(&category.gender);
+        let gender = athlete.gender.unwrap_or(category.gender).as_str();
 
         let normalized_name = NormalizedAthleteName::new(&athlete.first_name, &athlete.last_name);
         let (db_first_name, db_last_name) = normalized_name.as_database_tuple();
@@ -254,7 +257,7 @@ impl<'a> CanonicalTransformer<'a> {
             db_first_name,
             db_last_name,
             gender,
-            athlete.country
+            athlete.country.as_str()
         )
         .fetch_optional(&mut **tx)
         .await?;
@@ -276,8 +279,8 @@ impl<'a> CanonicalTransformer<'a> {
             db_first_name,
             db_last_name,
             gender,
-            athlete.country,
-            athlete.nationality,
+            athlete.country.as_str(),
+            athlete.nationality.map(|c| c.as_str().to_owned()),
             slug
         )
         .fetch_one(&mut **tx)

--- a/backend/crates/osl_importer/src/canonical/validator.rs
+++ b/backend/crates/osl_importer/src/canonical/validator.rs
@@ -9,10 +9,10 @@ impl CanonicalValidator {
     pub fn validate(canonical: &CanonicalFormat) -> Result<ValidationReport> {
         let mut report = ValidationReport::default();
 
-        if canonical.source.format_version != FORMAT_VERSION {
+        if canonical.format_version != FORMAT_VERSION {
             report.errors.push(format!(
                 "Unsupported format version: {}. Expected {}",
-                canonical.source.format_version, FORMAT_VERSION
+                canonical.format_version, FORMAT_VERSION
             ));
         }
 
@@ -31,11 +31,6 @@ impl CanonicalValidator {
             report
                 .errors
                 .push("Competition slug is required".to_string());
-        }
-        if canonical.competition.country.is_empty() {
-            report
-                .errors
-                .push("Competition country is required".to_string());
         }
         if canonical.competition.end_date < canonical.competition.start_date {
             report
@@ -59,10 +54,14 @@ impl CanonicalValidator {
                 .warnings
                 .push("Competition city is not specified".to_string());
         }
-        if canonical.competition.number_of_judges.is_none() {
-            report
+        match canonical.competition.number_of_judges {
+            None => report
                 .warnings
-                .push("Number of judges is not specified".to_string());
+                .push("Number of judges is not specified".to_string()),
+            Some(judges) if judges != 1 && judges != 3 => report
+                .errors
+                .push(format!("Number of judges must be 1 or 3, got {}", judges)),
+            Some(_) => {}
         }
 
         if canonical.movements.is_empty() {
@@ -103,10 +102,14 @@ impl CanonicalValidator {
                     .errors
                     .push("Category name cannot be empty".to_string());
             }
-            if category.gender != "M" && category.gender != "F" {
+            if category.weight_class_slug.is_some()
+                && (category.weight_class_max.is_some() || category.is_open_category.is_some())
+            {
                 report.errors.push(format!(
-                    "Invalid gender in category '{}': '{}'. Must be 'M' or 'F'",
-                    category.name, category.gender
+                    "Category '{}' sets weight_class_slug and raw bounds. The slug already \
+                     carries them, so keep the slug for a standard class and the raw fields \
+                     only for a non standard one",
+                    category.name
                 ));
             }
 
@@ -132,12 +135,6 @@ impl CanonicalValidator {
                         category.name
                     ));
                 }
-                if athlete.country.is_empty() {
-                    report
-                        .errors
-                        .push(format!("Athlete '{}' has empty country", athlete_label));
-                }
-
                 if athlete.bodyweight.is_none() {
                     report
                         .warnings
@@ -217,13 +214,13 @@ mod tests {
         MovementData, SourceMetadata, SourceType,
     };
     use chrono::NaiveDate;
-    use osl_domain::AthleteStatus;
+    use osl_domain::{AthleteStatus, CountryCode, Gender, WeightClassSlug};
     use rust_decimal::Decimal;
 
     fn minimal() -> CanonicalFormat {
         CanonicalFormat {
+            format_version: FORMAT_VERSION.to_string(),
             source: SourceMetadata {
-                format_version: FORMAT_VERSION.to_string(),
                 r#type: SourceType::Image,
                 url: None,
                 extracted_at: chrono::Utc::now(),
@@ -243,7 +240,7 @@ mod tests {
                 end_date: NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
                 venue: None,
                 city: None,
-                country: "FR".to_string(),
+                country: CountryCode::parse("FR").unwrap(),
                 number_of_judges: Some(3),
                 status: None,
             },
@@ -254,7 +251,7 @@ mod tests {
             }],
             categories: vec![CategoryData {
                 name: "M-80".to_string(),
-                gender: "M".to_string(),
+                gender: Gender::M,
                 weight_class_slug: None,
                 weight_class_max: Some(Decimal::from(80)),
                 is_open_category: None,
@@ -262,7 +259,7 @@ mod tests {
                     first_name: "Adrien".to_string(),
                     last_name: "Pelfresne".to_string(),
                     gender: None,
-                    country: "FR".to_string(),
+                    country: CountryCode::parse("FR").unwrap(),
                     nationality: None,
                     team: None,
                     bodyweight: Some(Decimal::from(78)),
@@ -290,7 +287,7 @@ mod tests {
     #[test]
     fn older_format_version_is_rejected() {
         let mut canonical = minimal();
-        canonical.source.format_version = "1.0.0".to_string();
+        canonical.format_version = "1.1.0".to_string();
 
         let err = CanonicalValidator::validate(&canonical)
             .unwrap_err()
@@ -307,6 +304,37 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("extractor is required"), "{err}");
+    }
+
+    #[test]
+    fn a_slug_alongside_raw_bounds_is_rejected() {
+        let mut canonical = minimal();
+        canonical.categories[0].weight_class_slug = Some(WeightClassSlug::M80);
+
+        let err = CanonicalValidator::validate(&canonical)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("weight_class_slug and raw bounds"), "{err}");
+    }
+
+    #[test]
+    fn a_slug_on_its_own_is_accepted() {
+        let mut canonical = minimal();
+        canonical.categories[0].weight_class_slug = Some(WeightClassSlug::M80);
+        canonical.categories[0].weight_class_max = None;
+
+        assert!(CanonicalValidator::validate(&canonical).is_ok());
+    }
+
+    #[test]
+    fn judge_counts_the_schema_rejects_fail_validation() {
+        let mut canonical = minimal();
+        canonical.competition.number_of_judges = Some(2);
+
+        let err = CanonicalValidator::validate(&canonical)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("must be 1 or 3"), "{err}");
     }
 
     #[test]

--- a/backend/imports/annecy-4-lift-2025/2026-05-22T11-15-23_annecy-4-lift-2025-dimanche-matin-39_liftcontrol.json
+++ b/backend/imports/annecy-4-lift-2025/2026-05-22T11-15-23_annecy-4-lift-2025-dimanche-matin-39_liftcontrol.json
@@ -1,6 +1,6 @@
 {
+  "format_version": "1.2.0",
   "source": {
-    "format_version": "1.1.0",
     "type": "api",
     "url": "https://app.liftcontrol.com/contest/annecy-4-lift-2025-dimanche-matin",
     "extracted_at": "2026-05-22T11:15:23.829688Z",
@@ -18,7 +18,7 @@
     "end_date": "2025-11-02",
     "venue": "Oski Crossfit",
     "city": "Annecy",
-    "country": "France",
+    "country": "FR",
     "number_of_judges": 3,
     "status": "completed"
   },
@@ -54,7 +54,7 @@
           "first_name": "Tom",
           "last_name": "Berthier",
           "country": "FR",
-          "nationality": "French",
+          "nationality": "FR",
           "bodyweight": "96.9",
           "status": "competed",
           "lifts": [
@@ -146,7 +146,7 @@
           "first_name": "Alix",
           "last_name": "DAVY",
           "country": "FR",
-          "nationality": "French",
+          "nationality": "FR",
           "bodyweight": "94.8",
           "status": "competed",
           "lifts": [
@@ -237,7 +237,7 @@
           "first_name": "Aghiles",
           "last_name": "HAMITI",
           "country": "FR",
-          "nationality": "French",
+          "nationality": "FR",
           "bodyweight": "94.7",
           "status": "competed",
           "lifts": [
@@ -329,7 +329,7 @@
           "first_name": "Timothée",
           "last_name": "MERANDON",
           "country": "FR",
-          "nationality": "French",
+          "nationality": "FR",
           "bodyweight": "88.7",
           "status": "competed",
           "lifts": [
@@ -420,7 +420,7 @@
           "first_name": "Gwendal",
           "last_name": "NADIYA",
           "country": "FR",
-          "nationality": "French",
+          "nationality": "FR",
           "bodyweight": "88.8",
           "status": "competed",
           "lifts": [
@@ -514,7 +514,7 @@
           "first_name": "Adrien",
           "last_name": "PELFRESNE",
           "country": "FR",
-          "nationality": "French",
+          "nationality": "FR",
           "bodyweight": "93.8",
           "status": "competed",
           "lifts": [
@@ -604,7 +604,7 @@
           "first_name": "Alex",
           "last_name": "PINOTTI",
           "country": "FR",
-          "nationality": "French",
+          "nationality": "FR",
           "bodyweight": "94.7",
           "status": "competed",
           "lifts": [
@@ -698,7 +698,7 @@
           "first_name": "Loïck",
           "last_name": "PIPOLO",
           "country": "FR",
-          "nationality": "French",
+          "nationality": "FR",
           "bodyweight": "92.1",
           "status": "competed",
           "lifts": [
@@ -789,7 +789,7 @@
           "first_name": "Antoine",
           "last_name": "REMBUR",
           "country": "FR",
-          "nationality": "French",
+          "nationality": "FR",
           "bodyweight": "88.2",
           "status": "competed",
           "lifts": [
@@ -889,7 +889,7 @@
           "first_name": "Nassim",
           "last_name": "AKEB",
           "country": "FR",
-          "nationality": "French",
+          "nationality": "FR",
           "bodyweight": "76.2",
           "status": "competed",
           "lifts": [
@@ -983,7 +983,7 @@
           "first_name": "Alexis",
           "last_name": "BONNAUD",
           "country": "FR",
-          "nationality": "French",
+          "nationality": "FR",
           "bodyweight": "76.5",
           "status": "competed",
           "lifts": [
@@ -1074,7 +1074,7 @@
           "first_name": "Remy",
           "last_name": "CARDY",
           "country": "FR",
-          "nationality": "French",
+          "nationality": "FR",
           "bodyweight": "77.9",
           "status": "competed",
           "lifts": [
@@ -1165,7 +1165,7 @@
           "first_name": "Morgan",
           "last_name": "CONTRUCCI",
           "country": "FR",
-          "nationality": "French",
+          "nationality": "FR",
           "bodyweight": "77.6",
           "status": "competed",
           "lifts": [
@@ -1260,7 +1260,7 @@
           "first_name": "Gregory",
           "last_name": "COSTE",
           "country": "FR",
-          "nationality": "French",
+          "nationality": "FR",
           "bodyweight": "78.4",
           "status": "competed",
           "lifts": [
@@ -1353,7 +1353,7 @@
           "first_name": "Thibault",
           "last_name": "DAUSQUE",
           "country": "FR",
-          "nationality": "French",
+          "nationality": "FR",
           "bodyweight": "79.9",
           "status": "competed",
           "lifts": [
@@ -1448,7 +1448,7 @@
           "first_name": "François",
           "last_name": "DELAVEAU",
           "country": "FR",
-          "nationality": "French",
+          "nationality": "FR",
           "bodyweight": "76.2",
           "status": "competed",
           "lifts": [
@@ -1544,7 +1544,7 @@
           "first_name": "Richard",
           "last_name": "Fanfano",
           "country": "FR",
-          "nationality": "French",
+          "nationality": "FR",
           "bodyweight": "75.6",
           "status": "competed",
           "lifts": [
@@ -1637,7 +1637,7 @@
           "first_name": "Anaël",
           "last_name": "GALOPIN",
           "country": "FR",
-          "nationality": "French",
+          "nationality": "FR",
           "bodyweight": "79.2",
           "status": "competed",
           "lifts": [
@@ -1730,7 +1730,7 @@
           "first_name": "Loyan",
           "last_name": "LANDES",
           "country": "FR",
-          "nationality": "French",
+          "nationality": "FR",
           "bodyweight": "76.1",
           "status": "competed",
           "lifts": [
@@ -1824,7 +1824,7 @@
           "first_name": "Noé",
           "last_name": "MASSIP",
           "country": "FR",
-          "nationality": "French",
+          "nationality": "FR",
           "bodyweight": "78.6",
           "status": "competed",
           "lifts": [
@@ -1917,7 +1917,7 @@
           "first_name": "Hugo",
           "last_name": "MEUNIER",
           "country": "FR",
-          "nationality": "French",
+          "nationality": "FR",
           "bodyweight": "74.6",
           "status": "competed",
           "lifts": [
@@ -2008,7 +2008,7 @@
           "first_name": "Gaëtan",
           "last_name": "Orru",
           "country": "FR",
-          "nationality": "French",
+          "nationality": "FR",
           "bodyweight": "74.9",
           "status": "competed",
           "lifts": [
@@ -2102,7 +2102,7 @@
           "first_name": "Ilyes",
           "last_name": "PELLETIER",
           "country": "FR",
-          "nationality": "French",
+          "nationality": "FR",
           "bodyweight": "75.5",
           "status": "competed",
           "lifts": [
@@ -2193,7 +2193,7 @@
           "first_name": "Alexandre",
           "last_name": "Thenoz",
           "country": "FR",
-          "nationality": "French",
+          "nationality": "FR",
           "bodyweight": "78.2",
           "status": "competed",
           "lifts": [


### PR DESCRIPTION
Closes OPE-80.

format_version moves to the document root so a reader can pick a parser before parsing. Country, gender and competition status become types, and a weight class can no longer set both the slug and raw bounds.