### PR TITLE
fix(ci): use github app token in cd and release deploy

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -80,9 +80,14 @@ jobs:
     needs: [build-backend, build-frontend]
     if: always() && !contains(needs.*.result, 'failure')
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
       - uses: actions/checkout@v7
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
       - name: Install yq
         run: |
           sudo wget -qO /usr/local/bin/yq \

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -105,8 +105,8 @@ jobs:
           fi
       - name: Commit
         run: |
-          git config user.name "ci-bot"
-          git config user.email "ci-bot@openstreetlifting.org"
+          git config user.name "osl-ci[bot]"
+          git config user.email "315316499+osl-ci[bot]@users.noreply.github.com"
           git add charts/values.yaml
           git diff --cached --quiet || git commit \
             -m "chore(deploy): bump images [skip ci]"

--- a/.github/workflows/release-deploy.yaml
+++ b/.github/workflows/release-deploy.yaml
@@ -65,8 +65,8 @@ jobs:
         run: |
           yq -i ".frontend.image.tag = \"${{ steps.tags.outputs.semver }}\"" charts/values.yaml
           yq -i ".backend.image.tag = \"${{ steps.tags.outputs.semver }}\"" charts/values.yaml
-          git config user.name "ci-bot"
-          git config user.email "ci-bot@openstreetlifting.org"
+          git config user.name "osl-ci[bot]"
+          git config user.email "315316499+osl-ci[bot]@users.noreply.github.com"
           git checkout main
           git add charts/values.yaml
           git commit \

--- a/.github/workflows/release-deploy.yaml
+++ b/.github/workflows/release-deploy.yaml
@@ -15,9 +15,14 @@ jobs:
     name: Retag & Pin Chart
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
       - uses: actions/checkout@v7
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - uses: docker/setup-buildx-action@v4

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -36,8 +36,8 @@ jobs:
         run: |
           gh pr checkout ${{ fromJson(steps.release.outputs.pr).number }}
           cargo generate-lockfile --manifest-path backend/Cargo.toml
-          git config user.name "ci-bot"
-          git config user.email "ci-bot@openstreetlifting.org"
+          git config user.name "osl-ci[bot]"
+          git config user.email "315316499+osl-ci[bot]@users.noreply.github.com"
           git add backend/Cargo.lock
           git diff --cached --quiet || git commit \
             -m "chore(backend): update Cargo.lock after version bump [skip ci]"


### PR DESCRIPTION
The two remaining workflows still used the deleted RELEASE_PLEASE_TOKEN, so checkout got an empty token. Also unifies the CI commit identity to osl-ci[bot].