### PR TITLE
fix(importer): apply corrections on re-import

### DIFF
--- a/backend/.sqlx/query-0438982149d0e5e70098938652f08c0e6086d24cd0339e85fd356b656e4fcdd6.json
+++ b/backend/.sqlx/query-0438982149d0e5e70098938652f08c0e6086d24cd0339e85fd356b656e4fcdd6.json
@@ -1,0 +1,38 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT weight_class_min, weight_class_max FROM categories WHERE name = 'Test category'",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "weight_class_min",
+        "type_info": "Numeric",
+        "origin": {
+          "Table": {
+            "table": "categories",
+            "name": "weight_class_min"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "weight_class_max",
+        "type_info": "Numeric",
+        "origin": {
+          "Table": {
+            "table": "categories",
+            "name": "weight_class_max"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      true,
+      true
+    ]
+  },
+  "hash": "0438982149d0e5e70098938652f08c0e6086d24cd0339e85fd356b656e4fcdd6"
+}

--- a/backend/.sqlx/query-1eaab3f870c593023df78ea6895b77e8797a8a46ca40c3a06a2ea2bd4d7bfd22.json
+++ b/backend/.sqlx/query-1eaab3f870c593023df78ea6895b77e8797a8a46ca40c3a06a2ea2bd4d7bfd22.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT nationality FROM athletes WHERE last_name = 'Doe'",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "nationality",
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "athletes",
+            "name": "nationality"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "1eaab3f870c593023df78ea6895b77e8797a8a46ca40c3a06a2ea2bd4d7bfd22"
+}

--- a/backend/.sqlx/query-a23be0bad997cddbc921c007500d8df44d34bdc39507bbda96dcbdabe97668b1.json
+++ b/backend/.sqlx/query-a23be0bad997cddbc921c007500d8df44d34bdc39507bbda96dcbdabe97668b1.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                UPDATE categories\n                SET weight_class_min = $1, weight_class_max = $2\n                WHERE category_id = $3\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Numeric",
+        "Numeric",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "a23be0bad997cddbc921c007500d8df44d34bdc39507bbda96dcbdabe97668b1"
+}

--- a/backend/.sqlx/query-a53fff8a48a10bf89d0cc7a355ce166441ab15d5def403faee754ebecf911ebb.json
+++ b/backend/.sqlx/query-a53fff8a48a10bf89d0cc7a355ce166441ab15d5def403faee754ebecf911ebb.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                UPDATE athletes\n                SET nationality = COALESCE($1, nationality)\n                WHERE athlete_id = $2\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "a53fff8a48a10bf89d0cc7a355ce166441ab15d5def403faee754ebecf911ebb"
+}

--- a/backend/.sqlx/query-db8f9ffc6f0b976803672ce3a74e2a4f401cc8746b6226a9f03c2cfd81134ade.json
+++ b/backend/.sqlx/query-db8f9ffc6f0b976803672ce3a74e2a4f401cc8746b6226a9f03c2cfd81134ade.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                UPDATE federations\n                SET abbreviation = COALESCE($1, abbreviation),\n                    country = COALESCE($2, country)\n                WHERE federation_id = $3\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "db8f9ffc6f0b976803672ce3a74e2a4f401cc8746b6226a9f03c2cfd81134ade"
+}

--- a/backend/crates/osl_importer/src/canonical/transformer.rs
+++ b/backend/crates/osl_importer/src/canonical/transformer.rs
@@ -101,6 +101,20 @@ impl<'a> CanonicalTransformer<'a> {
         .await?;
 
         if let Some(id) = existing {
+            sqlx::query!(
+                r#"
+                UPDATE federations
+                SET abbreviation = COALESCE($1, abbreviation),
+                    country = COALESCE($2, country)
+                WHERE federation_id = $3
+                "#,
+                federation.abbreviation,
+                federation.country.map(|c| c.as_str().to_owned()),
+                id
+            )
+            .execute(&mut **tx)
+            .await?;
+
             return Ok(id);
         }
 
@@ -166,14 +180,27 @@ impl<'a> CanonicalTransformer<'a> {
         .fetch_optional(&mut **tx)
         .await?;
 
-        if let Some(id) = existing {
-            return Ok(id);
-        }
-
         let (min, max) = match category.weight_class_slug.as_ref() {
             Some(slug) => slug.bounds(),
             None => (None, category.weight_class_max),
         };
+
+        if let Some(id) = existing {
+            sqlx::query!(
+                r#"
+                UPDATE categories
+                SET weight_class_min = $1, weight_class_max = $2
+                WHERE category_id = $3
+                "#,
+                min,
+                max,
+                id
+            )
+            .execute(&mut **tx)
+            .await?;
+
+            return Ok(id);
+        }
 
         let category_id = sqlx::query_scalar!(
             r#"
@@ -263,6 +290,19 @@ impl<'a> CanonicalTransformer<'a> {
         .await?;
 
         if let Some(id) = existing {
+            // COALESCE because a missing nationality means unknown, not cleared.
+            sqlx::query!(
+                r#"
+                UPDATE athletes
+                SET nationality = COALESCE($1, nationality)
+                WHERE athlete_id = $2
+                "#,
+                athlete.nationality.map(|c| c.as_str().to_owned()),
+                id
+            )
+            .execute(&mut **tx)
+            .await?;
+
             return Ok(id);
         }
 

--- a/backend/crates/osl_importer/tests/reimport.rs
+++ b/backend/crates/osl_importer/tests/reimport.rs
@@ -1,0 +1,123 @@
+//! A canonical file is built up over several passes, so importing a corrected
+//! file has to land the correction rather than stop at the row already there.
+
+use osl_importer::canonical::{models::CanonicalFormat, transformer::CanonicalTransformer};
+use rust_decimal::Decimal;
+use sqlx::PgPool;
+
+fn canonical(weight_class_slug: &str, nationality: Option<&str>) -> CanonicalFormat {
+    let nationality = match nationality {
+        Some(code) => format!(r#""nationality": "{}","#, code),
+        None => String::new(),
+    };
+
+    serde_json::from_str(&format!(
+        r#"{{
+          "format_version": "1.2.0",
+          "source": {{
+            "type": "manual",
+            "extracted_at": "2025-06-01T10:00:00Z",
+            "extractor": "test"
+          }},
+          "competition": {{
+            "name": "Test Open",
+            "slug": "test-open",
+            "federation": {{ "name": "Test Federation" }},
+            "start_date": "2025-06-01",
+            "end_date": "2025-06-01",
+            "country": "FR"
+          }},
+          "movements": [{{ "name": "Pull-up", "order": 1 }}],
+          "categories": [
+            {{
+              "name": "Test category",
+              "gender": "M",
+              "weight_class_slug": "{}",
+              "athletes": [
+                {{
+                  "first_name": "John",
+                  "last_name": "Doe",
+                  "country": "FR",
+                  {}
+                  "bodyweight": "72.5",
+                  "status": "competed",
+                  "lifts": [
+                    {{
+                      "movement": "Pull-up",
+                      "attempts": [
+                        {{ "attempt_number": 1, "weight": "60", "is_successful": true }}
+                      ]
+                    }}
+                  ]
+                }}
+              ]
+            }}
+          ]
+        }}"#,
+        weight_class_slug, nationality
+    ))
+    .expect("fixture is a valid canonical file")
+}
+
+#[sqlx::test(migrations = "../osl_db/migrations")]
+async fn reimport_corrects_athlete_nationality(pool: PgPool) {
+    let transformer = CanonicalTransformer::new(&pool);
+
+    transformer
+        .import_to_database(canonical("M-73", Some("US")))
+        .await
+        .unwrap();
+    transformer
+        .import_to_database(canonical("M-73", Some("FR")))
+        .await
+        .unwrap();
+
+    let athlete = sqlx::query!(r#"SELECT nationality FROM athletes WHERE last_name = 'Doe'"#)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(athlete.nationality.as_deref(), Some("FR"));
+}
+
+#[sqlx::test(migrations = "../osl_db/migrations")]
+async fn reimport_corrects_category_bounds(pool: PgPool) {
+    let transformer = CanonicalTransformer::new(&pool);
+
+    transformer
+        .import_to_database(canonical("M-73", Some("FR")))
+        .await
+        .unwrap();
+    transformer
+        .import_to_database(canonical("M-80", Some("FR")))
+        .await
+        .unwrap();
+
+    let category = sqlx::query!(
+        r#"SELECT weight_class_min, weight_class_max FROM categories WHERE name = 'Test category'"#
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(category.weight_class_min, Some(Decimal::from(73)));
+    assert_eq!(category.weight_class_max, Some(Decimal::from(80)));
+}
+
+#[sqlx::test(migrations = "../osl_db/migrations")]
+async fn reimport_without_nationality_keeps_the_known_one(pool: PgPool) {
+    let transformer = CanonicalTransformer::new(&pool);
+
+    transformer
+        .import_to_database(canonical("M-73", Some("FR")))
+        .await
+        .unwrap();
+    transformer
+        .import_to_database(canonical("M-73", None))
+        .await
+        .unwrap();
+
+    let athlete = sqlx::query!(r#"SELECT nationality FROM athletes WHERE last_name = 'Doe'"#)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(athlete.nationality.as_deref(), Some("FR"));
+}


### PR DESCRIPTION
Athletes, categories and federations were insert-or-ignore, so editing a canonical file and re-importing changed nothing. They now update the existing row.