### PR TITLE
feat(importer)!: canonical format 1.3.0 with explicit weight class bounds

### DIFF
--- a/.claude/skills/extract-competition/SKILL.md
+++ b/.claude/skills/extract-competition/SKILL.md
@@ -62,12 +62,12 @@ them loses real data.
 
 ## Format
 
-`format_version` is `1.2.0`. Required fields have no marker; `?` means
+`format_version` is `1.3.0`. Required fields have no marker; `?` means
 optional and should be omitted when unknown.
 
 ```jsonc
 {
-  "format_version": "1.2.0",
+  "format_version": "1.3.0",
   "source": {
     "type": "html",              // api | html | pdf | csv | image | manual
     "url": "https://...",        // ?
@@ -99,9 +99,7 @@ optional and should be omitted when unknown.
     {
       "name": "Catégorie -80",
       "gender": "M",             // M, F or MX
-      "weight_class_slug": "M-80",   // ? standard class, see list below
-      "weight_class_max": "80",      // ? non standard class only
-      "is_open_category": true,      // ? non standard class only
+      "weight_class_slug": "M-80",   // standard class, see list below
       "athletes": [
         {
           "first_name": "Timothée",
@@ -128,16 +126,32 @@ optional and should be omitted when unknown.
           ]
         }
       ]
+    },
+    {
+      // A class outside the standard ladder, stated as bounds.
+      "name": "Catégorie +87",
+      "gender": "M",
+      "weight_class_min": "87",      // above 87, no upper limit
+      "athletes": []
     }
   ]
 }
 ```
 
-`weight_class_slug` is one of: `F-52` `F-57` `F-63` `F-70` `F+70` `M-66`
-`M-73` `M-80` `M-87` `M-94` `M-101` `M+101`. It already carries the bounds,
-so a category using it must not also set `weight_class_max` or
-`is_open_category`. Use those two only for a class outside the standard
-ladder, such as a local meet running -75.
+Every category needs a weight class, in one of two ways.
+
+Use `weight_class_slug` for a standard class. It is one of `F-52` `F-57`
+`F-63` `F-70` `F+70` `M-66` `M-73` `M-80` `M-87` `M-94` `M-101` `M+101`, and
+it already carries the bounds, so a category using it must not also set
+`weight_class_min` or `weight_class_max`.
+
+Use the raw bounds for anything else: a meet running -75, or an open class
+like +87 that merges the top of the ladder. `weight_class_min` is the lower
+bound and `weight_class_max` the upper, and a class may set one or both.
+`-75` is `weight_class_max: "75"`, `+87` is `weight_class_min: "87"`.
+
+Read the bound off the category name, not off the athletes. A class called
++87 has a minimum of 87 even when the lightest athlete in it weighs 91.
 
 Weights and bodyweights are JSON **strings**, not numbers. Countries are ISO
 3166-1 alpha-2, so `FR` and never `France` or `FRA`.
@@ -147,14 +161,15 @@ Weights and bodyweights are JSON **strings**, not numbers. Countries are ISO
 Wrong `format_version`, empty `extractor`, a country that is not two letters,
 a gender outside `M` `F` `MX`, a status outside the five listed, a judge count
 other than 1 or 3, `end_date` before `start_date`, a duplicate or unnamed
-movement, a movement `order` below 1, a weight class setting both the slug and
-the raw bounds, a lift naming a movement not in `movements`, a lift with no
-attempts, an `attempt_number` outside 1 to 3, a negative weight.
+movement, a movement `order` below 1, a category setting both the slug and the
+raw bounds, a `weight_class_min` above its `weight_class_max`, a lift naming a
+movement not in `movements`, a lift with no attempts, an `attempt_number`
+outside 1 to 3, a negative weight.
 
 ### What it only warns about
 
-Missing venue, city, judges or bodyweight. A category with no athletes. An
-athlete with no lifts. These are normal for a file still being built, so
+Missing venue, city, judges or bodyweight. A category with no weight class at
+all. A category with no athletes. An athlete with no lifts. These are normal for a file still being built, so
 warnings are expected mid-construction and are not something to fix by
 inventing data.
 

--- a/backend/crates/osl_importer/src/canonical/format.rs
+++ b/backend/crates/osl_importer/src/canonical/format.rs
@@ -34,6 +34,9 @@ pub fn normalize(canonical: &mut CanonicalFormat) {
     canonical.categories.sort_by(|a, b| a.name.cmp(&b.name));
 
     for category in &mut canonical.categories {
+        if let Some(min) = category.weight_class_min.as_mut() {
+            *min = min.normalize();
+        }
         if let Some(max) = category.weight_class_max.as_mut() {
             *max = max.normalize();
         }
@@ -162,8 +165,8 @@ mod tests {
                     name: "M-87".to_string(),
                     gender: Gender::M,
                     weight_class_slug: None,
+                    weight_class_min: None,
                     weight_class_max: Some(Decimal::from_str("87.0").unwrap()),
-                    is_open_category: None,
                     athletes: vec![
                         athlete("Bob", "Zulu", &["Squat", "Muscle-up"]),
                         athlete("Alice", "Alpha", &["Squat", "Muscle-up"]),
@@ -173,8 +176,8 @@ mod tests {
                     name: "M-80".to_string(),
                     gender: Gender::M,
                     weight_class_slug: None,
+                    weight_class_min: None,
                     weight_class_max: Some(Decimal::from(80)),
-                    is_open_category: None,
                     athletes: vec![],
                 },
             ],

--- a/backend/crates/osl_importer/src/canonical/models.rs
+++ b/backend/crates/osl_importer/src/canonical/models.rs
@@ -4,7 +4,7 @@ use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
 /// Format version this build reads and writes.
-pub const FORMAT_VERSION: &str = "1.2.0";
+pub const FORMAT_VERSION: &str = "1.3.0";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CanonicalFormat {
@@ -115,11 +115,12 @@ pub struct CategoryData {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub weight_class_slug: Option<WeightClassSlug>,
 
+    /// Lower bound, exclusive. Set on its own for an open class such as +87.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub weight_class_max: Option<Decimal>,
+    pub weight_class_min: Option<Decimal>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub is_open_category: Option<bool>,
+    pub weight_class_max: Option<Decimal>,
 
     pub athletes: Vec<AthleteData>,
 }

--- a/backend/crates/osl_importer/src/canonical/transformer.rs
+++ b/backend/crates/osl_importer/src/canonical/transformer.rs
@@ -182,7 +182,7 @@ impl<'a> CanonicalTransformer<'a> {
 
         let (min, max) = match category.weight_class_slug.as_ref() {
             Some(slug) => slug.bounds(),
-            None => (None, category.weight_class_max),
+            None => (category.weight_class_min, category.weight_class_max),
         };
 
         if let Some(id) = existing {

--- a/backend/crates/osl_importer/src/canonical/validator.rs
+++ b/backend/crates/osl_importer/src/canonical/validator.rs
@@ -102,13 +102,33 @@ impl CanonicalValidator {
                     .errors
                     .push("Category name cannot be empty".to_string());
             }
-            if category.weight_class_slug.is_some()
-                && (category.weight_class_max.is_some() || category.is_open_category.is_some())
-            {
+            let has_raw_bounds =
+                category.weight_class_min.is_some() || category.weight_class_max.is_some();
+
+            if category.weight_class_slug.is_some() && has_raw_bounds {
                 report.errors.push(format!(
                     "Category '{}' sets weight_class_slug and raw bounds. The slug already \
-                     carries them, so keep the slug for a standard class and the raw fields \
+                     carries them, so keep the slug for a standard class and the raw bounds \
                      only for a non standard one",
+                    category.name
+                ));
+            }
+
+            if let (Some(min), Some(max)) = (category.weight_class_min, category.weight_class_max)
+                && min >= max
+            {
+                report.errors.push(format!(
+                    "Category '{}' has weight_class_min {} above weight_class_max {}",
+                    category.name, min, max
+                ));
+            }
+
+            // Without a bound the class limit lives only in the name, so it is
+            // lost as data. The +87 category was imported that way.
+            if category.weight_class_slug.is_none() && !has_raw_bounds {
+                report.warnings.push(format!(
+                    "Category '{}' has no weight class. Set weight_class_slug for a standard \
+                     class, or weight_class_min and weight_class_max for a non standard one",
                     category.name
                 ));
             }
@@ -253,8 +273,8 @@ mod tests {
                 name: "M-80".to_string(),
                 gender: Gender::M,
                 weight_class_slug: None,
+                weight_class_min: None,
                 weight_class_max: Some(Decimal::from(80)),
-                is_open_category: None,
                 athletes: vec![AthleteData {
                     first_name: "Adrien".to_string(),
                     last_name: "Pelfresne".to_string(),

--- a/backend/crates/osl_importer/tests/reimport.rs
+++ b/backend/crates/osl_importer/tests/reimport.rs
@@ -5,7 +5,9 @@ use osl_importer::canonical::{models::CanonicalFormat, transformer::CanonicalTra
 use rust_decimal::Decimal;
 use sqlx::PgPool;
 
-fn canonical(weight_class_slug: &str, nationality: Option<&str>) -> CanonicalFormat {
+/// `weight_class` is the raw JSON for the class fields, so a test can pass a
+/// slug or raw bounds without a second fixture.
+fn canonical(weight_class: &str, nationality: Option<&str>) -> CanonicalFormat {
     let nationality = match nationality {
         Some(code) => format!(r#""nationality": "{}","#, code),
         None => String::new(),
@@ -13,7 +15,7 @@ fn canonical(weight_class_slug: &str, nationality: Option<&str>) -> CanonicalFor
 
     serde_json::from_str(&format!(
         r#"{{
-          "format_version": "1.2.0",
+          "format_version": "1.3.0",
           "source": {{
             "type": "manual",
             "extracted_at": "2025-06-01T10:00:00Z",
@@ -32,7 +34,7 @@ fn canonical(weight_class_slug: &str, nationality: Option<&str>) -> CanonicalFor
             {{
               "name": "Test category",
               "gender": "M",
-              "weight_class_slug": "{}",
+              {}
               "athletes": [
                 {{
                   "first_name": "John",
@@ -54,9 +56,13 @@ fn canonical(weight_class_slug: &str, nationality: Option<&str>) -> CanonicalFor
             }}
           ]
         }}"#,
-        weight_class_slug, nationality
+        weight_class, nationality
     ))
     .expect("fixture is a valid canonical file")
+}
+
+fn slug(slug: &str) -> String {
+    format!(r#""weight_class_slug": "{}","#, slug)
 }
 
 #[sqlx::test(migrations = "../osl_db/migrations")]
@@ -64,11 +70,11 @@ async fn reimport_corrects_athlete_nationality(pool: PgPool) {
     let transformer = CanonicalTransformer::new(&pool);
 
     transformer
-        .import_to_database(canonical("M-73", Some("US")))
+        .import_to_database(canonical(&slug("M-73"), Some("US")))
         .await
         .unwrap();
     transformer
-        .import_to_database(canonical("M-73", Some("FR")))
+        .import_to_database(canonical(&slug("M-73"), Some("FR")))
         .await
         .unwrap();
 
@@ -84,11 +90,11 @@ async fn reimport_corrects_category_bounds(pool: PgPool) {
     let transformer = CanonicalTransformer::new(&pool);
 
     transformer
-        .import_to_database(canonical("M-73", Some("FR")))
+        .import_to_database(canonical(&slug("M-73"), Some("FR")))
         .await
         .unwrap();
     transformer
-        .import_to_database(canonical("M-80", Some("FR")))
+        .import_to_database(canonical(&slug("M-80"), Some("FR")))
         .await
         .unwrap();
 
@@ -103,15 +109,34 @@ async fn reimport_corrects_category_bounds(pool: PgPool) {
 }
 
 #[sqlx::test(migrations = "../osl_db/migrations")]
+async fn open_class_is_stored_as_a_lower_bound(pool: PgPool) {
+    let transformer = CanonicalTransformer::new(&pool);
+
+    transformer
+        .import_to_database(canonical(r#""weight_class_min": "87","#, Some("FR")))
+        .await
+        .unwrap();
+
+    let category = sqlx::query!(
+        r#"SELECT weight_class_min, weight_class_max FROM categories WHERE name = 'Test category'"#
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(category.weight_class_min, Some(Decimal::from(87)));
+    assert_eq!(category.weight_class_max, None);
+}
+
+#[sqlx::test(migrations = "../osl_db/migrations")]
 async fn reimport_without_nationality_keeps_the_known_one(pool: PgPool) {
     let transformer = CanonicalTransformer::new(&pool);
 
     transformer
-        .import_to_database(canonical("M-73", Some("FR")))
+        .import_to_database(canonical(&slug("M-73"), Some("FR")))
         .await
         .unwrap();
     transformer
-        .import_to_database(canonical("M-73", None))
+        .import_to_database(canonical(&slug("M-73"), None))
         .await
         .unwrap();
 

--- a/backend/imports/annecy-4-lift-2025/2026-05-22T11-15-23_annecy-4-lift-2025-dimanche-matin-39_liftcontrol.json
+++ b/backend/imports/annecy-4-lift-2025/2026-05-22T11-15-23_annecy-4-lift-2025-dimanche-matin-39_liftcontrol.json
@@ -1,5 +1,5 @@
 {
-  "format_version": "1.2.0",
+  "format_version": "1.3.0",
   "source": {
     "type": "api",
     "url": "https://app.liftcontrol.com/contest/annecy-4-lift-2025-dimanche-matin",
@@ -48,7 +48,7 @@
     {
       "name": "Catégorie +87",
       "gender": "M",
-      "is_open_category": true,
+      "weight_class_min": "87",
       "athletes": [
         {
           "first_name": "Tom",


### PR DESCRIPTION
is_open_category was read by nothing, so an open class like +87 stored no bounds at all. Replaced by weight_class_min, so the file states the bounds directly.