### PR TITLE
feat(db): add weight_classes table keyed on bounds

### DIFF
--- a/backend/crates/osl_db/migrations/20260811100000_add_weight_classes.sql
+++ b/backend/crates/osl_db/migrations/20260811100000_add_weight_classes.sql
@@ -1,0 +1,38 @@
+-- A weight class is identified by its bounds, not by its name. "Catégorie +87",
+-- "+87 kg" and "M+87" are one class, so keying on the label forks it into
+-- three. The unique constraint below is what stops that.
+
+CREATE TABLE IF NOT EXISTS "weight_classes" (
+    "weight_class_id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "gender" VARCHAR(10) NOT NULL CHECK (gender IN ('M', 'F', 'MX')),
+    "min_kg" DECIMAL CHECK (min_kg > 0),
+    "max_kg" DECIMAL CHECK (max_kg > 0),
+    "slug" VARCHAR(20) UNIQUE,
+    "created_at" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY ("weight_class_id"),
+    CONSTRAINT "weight_class_has_a_bound" CHECK (min_kg IS NOT NULL OR max_kg IS NOT NULL),
+    CONSTRAINT "weight_class_bounds_ordered" CHECK (min_kg IS NULL OR max_kg IS NULL OR max_kg > min_kg),
+    -- Postgres treats NULLs as distinct by default, so a plain UNIQUE would
+    -- accept two (M, 87, NULL) rows and reintroduce the duplicates.
+    CONSTRAINT "weight_class_bounds_unique" UNIQUE NULLS NOT DISTINCT ("gender", "min_kg", "max_kg")
+);
+
+CREATE INDEX "weight_classes_index_0" ON "weight_classes" ("gender");
+
+-- The standard ladder. A class outside it is an ordinary row with a NULL slug.
+INSERT INTO weight_classes (gender, min_kg, max_kg, slug)
+VALUES
+    ('F', NULL, 52,   'F-52'),
+    ('F', 52,   57,   'F-57'),
+    ('F', 57,   63,   'F-63'),
+    ('F', 63,   70,   'F-70'),
+    ('F', 70,   NULL, 'F+70'),
+    ('M', NULL, 66,   'M-66'),
+    ('M', 66,   73,   'M-73'),
+    ('M', 73,   80,   'M-80'),
+    ('M', 80,   87,   'M-87'),
+    ('M', 87,   94,   'M-94'),
+    ('M', 94,   101,  'M-101'),
+    ('M', 101,  NULL, 'M+101')
+ON CONFLICT (gender, min_kg, max_kg) DO UPDATE
+SET slug = EXCLUDED.slug;

--- a/backend/crates/osl_db/tests/weight_classes.rs
+++ b/backend/crates/osl_db/tests/weight_classes.rs
@@ -1,0 +1,54 @@
+//! The unique constraint on bounds is the only thing preventing duplicate
+//! weight classes, so it is worth asserting rather than assuming.
+
+use rust_decimal::Decimal;
+use sqlx::PgPool;
+
+async fn insert(
+    pool: &PgPool,
+    gender: &str,
+    min: Option<i32>,
+    max: Option<i32>,
+) -> sqlx::Result<()> {
+    sqlx::query("INSERT INTO weight_classes (gender, min_kg, max_kg) VALUES ($1, $2, $3)")
+        .bind(gender)
+        .bind(min.map(Decimal::from))
+        .bind(max.map(Decimal::from))
+        .execute(pool)
+        .await
+        .map(|_| ())
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn the_standard_ladder_is_seeded(pool: PgPool) {
+    let count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM weight_classes WHERE slug IS NOT NULL")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(count, 12);
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn the_same_bounds_cannot_be_inserted_twice(pool: PgPool) {
+    insert(&pool, "M", Some(75), Some(82)).await.unwrap();
+    assert!(insert(&pool, "M", Some(75), Some(82)).await.is_err());
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn an_open_class_cannot_be_inserted_twice(pool: PgPool) {
+    // NULLS NOT DISTINCT is what makes this fail. A plain UNIQUE would let
+    // both rows through, since Postgres reads two NULLs as different values.
+    insert(&pool, "M", Some(120), None).await.unwrap();
+    assert!(insert(&pool, "M", Some(120), None).await.is_err());
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn a_class_with_no_bound_is_rejected(pool: PgPool) {
+    assert!(insert(&pool, "M", None, None).await.is_err());
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn bounds_in_the_wrong_order_are_rejected(pool: PgPool) {
+    assert!(insert(&pool, "M", Some(90), Some(80)).await.is_err());
+}


### PR DESCRIPTION
Identity is (gender, min, max) so the same class under a different name cannot fork. NULLS NOT DISTINCT is what makes that hold for open classes.