### PR TITLE
chore: fix local dev setup and document it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-launch_local.sh
+.DS_Store
+REFACTOR.md

--- a/README.md
+++ b/README.md
@@ -11,37 +11,30 @@ This Readme only cover developer documentation, if you want to know about the wh
 
 ## Run locally
 
-The project is a monorepo: a Rust backend (ETL pipeline, API, DB, domain) and a SvelteKit frontend.
-
-Postgres runs in a container so it matches CI. The backend and frontend run natively, because
-building Rust inside a container throws away the incremental cache on every change.
-
-Requirements: docker, rust with `sqlx-cli`, pnpm.
+Requires docker, rust with `sqlx-cli`, and pnpm.
 
 ```sh
-cp backend/.env.example backend/.env      # defaults match the compose file
+cp backend/.env.example backend/.env
 docker compose up -d --wait postgres
-cd backend && sqlx migrate run --source crates/osl_db/migrations
-cargo run -p osl_importer --bin import -- bulk-import   # loads backend/imports/*.json
+cd backend
+sqlx migrate run --source crates/osl_db/migrations
+cargo run -p osl_importer --bin import -- bulk-import
 cd ../frontend && pnpm install
 ```
-
-Then start both servers:
 
 ```sh
 ./launch_local.sh
 ```
 
-The API is on <http://localhost:8080> (Swagger at `/swagger-ui/`) and the frontend on
-<http://localhost:5173>. `cargo install cargo-watch` to get backend reload.
+API on <http://localhost:8080>, Swagger at `/swagger-ui/`, frontend on <http://localhost:5173>.
 
-To start over, drop the database and repeat from the migration step:
+Reset the database, then rerun the migration and import:
 
 ```sh
 cd backend && sqlx database drop -y && sqlx database create
 ```
 
-The full stack in containers is still available, and is what CI and production build:
+Everything in containers:
 
 ```sh
 docker compose up -d --build

--- a/README.md
+++ b/README.md
@@ -11,14 +11,41 @@ This Readme only cover developer documentation, if you want to know about the wh
 
 ## Run locally
 
-The project architecture is a monorepo, containing the Rust backend (ETL Pipeline, API, DB, Domain), and the Svelte Kit Frontend.
-You can either run the project by using the [docker compose](./docker-compose.yaml)
+The project is a monorepo: a Rust backend (ETL pipeline, API, DB, domain) and a SvelteKit frontend.
+
+Postgres runs in a container so it matches CI. The backend and frontend run natively, because
+building Rust inside a container throws away the incremental cache on every change.
+
+Requirements: docker, rust with `sqlx-cli`, pnpm.
+
+```sh
+cp backend/.env.example backend/.env      # defaults match the compose file
+docker compose up -d --wait postgres
+cd backend && sqlx migrate run --source crates/osl_db/migrations
+cargo run -p osl_importer --bin import -- bulk-import   # loads backend/imports/*.json
+cd ../frontend && pnpm install
+```
+
+Then start both servers:
+
+```sh
+./launch_local.sh
+```
+
+The API is on <http://localhost:8080> (Swagger at `/swagger-ui/`) and the frontend on
+<http://localhost:5173>. `cargo install cargo-watch` to get backend reload.
+
+To start over, drop the database and repeat from the migration step:
+
+```sh
+cd backend && sqlx database drop -y && sqlx database create
+```
+
+The full stack in containers is still available, and is what CI and production build:
 
 ```sh
 docker compose up -d --build
 ```
-
-Or by running each service individually
 
 ## Contributing
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,19 +3,21 @@ services:
     image: postgres:18
     container_name: openstreetlifting_postgres
     restart: unless-stopped
+    # Defaults match backend/.env.example so `docker compose up -d postgres`
+    # works from a fresh clone with no root .env.
     environment:
-      POSTGRES_USER: ${DB_USER}
-      POSTGRES_PASSWORD: ${DB_PASSWORD}
-      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_USER: ${DB_USER:-appuser}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-apppassword}
+      POSTGRES_DB: ${DB_NAME:-appdb}
     shm_size: 128mb
     ports:
-      - "${DB_PORT}:5432"
+      - "${DB_PORT:-5432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql
     networks:
       - app-network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}"]
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-appuser} -d ${DB_NAME:-appdb}"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -31,9 +33,9 @@ services:
     environment:
       DB_HOST: postgres
       HOST: 0.0.0.0
-      DATABASE_URL: postgresql://${DB_USER}:${DB_PASSWORD}@postgres:5432/${DB_NAME}
+      DATABASE_URL: postgresql://${DB_USER:-appuser}:${DB_PASSWORD:-apppassword}@postgres:5432/${DB_NAME:-appdb}
     ports:
-      - "${PORT}:8080"
+      - "${PORT:-8080}:8080"
     networks:
       - app-network
     depends_on:
@@ -48,7 +50,7 @@ services:
     env_file:
       - .env
     environment:
-      DATABASE_URL: postgresql://${DB_USER}:${DB_PASSWORD}@postgres:5432/${DB_NAME}
+      DATABASE_URL: postgresql://${DB_USER:-appuser}:${DB_PASSWORD:-apppassword}@postgres:5432/${DB_NAME:-appdb}
     networks:
       - app-network
     depends_on:

--- a/launch_local.sh
+++ b/launch_local.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Postgres runs in a container so it matches CI. The backend and frontend run
+# natively, because a bind mounted target directory turns a 15 second
+# incremental build into a cold one.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+for tool in docker cargo pnpm; do
+  command -v "$tool" >/dev/null || { echo "$tool is required but not installed"; exit 1; }
+done
+
+if [ ! -f backend/.env ]; then
+  echo "backend/.env is missing. Copy backend/.env.example and fill it in."
+  exit 1
+fi
+
+# --wait blocks on the healthcheck, so migrations cannot race the database.
+docker compose up -d --wait postgres
+
+if command -v cargo-watch >/dev/null; then
+  backend_cmd=(cargo watch -x "run -p osl_api")
+else
+  echo "cargo-watch not found, running without reload. cargo install cargo-watch"
+  backend_cmd=(cargo run -p osl_api)
+fi
+
+# Kill the whole process group on exit so neither server is orphaned.
+trap 'trap - EXIT; kill 0' EXIT INT TERM
+
+(cd backend && "${backend_cmd[@]}") &
+(cd frontend && pnpm dev) &
+wait

--- a/launch_local.sh
+++ b/launch_local.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-# Postgres runs in a container so it matches CI. The backend and frontend run
-# natively, because a bind mounted target directory turns a 15 second
-# incremental build into a cold one.
+# Postgres in a container to match CI. The apps run natively, rebuilding Rust
+# in a container is too slow to work with.
 set -euo pipefail
 
 cd "$(dirname "$0")"


### PR DESCRIPTION
launch_local.sh pointed at a compose file that no longer exists and used npm on a pnpm project. Compose now has defaults so it runs from a fresh clone, and the README has the steps to get local data.