### PR TITLE
fix(db): store a bodyweight lift and a bombed movement

### DIFF
--- a/.claude/skills/extract-competition/SKILL.md
+++ b/.claude/skills/extract-competition/SKILL.md
@@ -60,6 +60,20 @@ same person under a different spelling. Ask. Do not pick.
 are part of the result and they affect nothing in the total, but removing
 them loses real data.
 
+**Zero is a weight, not a blank.** A muscle-up, pull-up or dip with no added
+weight is a real lift, and a source may write it as `0 kg`. A successful 0 kg
+attempt is recorded like any other, with `"weight": "0"`.
+
+A source may also print `0 kg` to mean the opposite: nothing was lifted, or
+the athlete never competed. That is not an attempt and is not written to the
+file at all. Tell them apart the same way as any other attempt, by whether the
+source marks it successful. If the source gives you no way to tell, ask.
+
+An athlete who missed every attempt in a movement still gets that movement,
+with all their failed attempts in it. Do not drop the movement and do not
+invent a zero for it: they contested it and lifted nothing, which is different
+from lifting their bodyweight.
+
 ## Format
 
 `format_version` is `1.5.0`. Required fields have no marker; `?` means
@@ -185,7 +199,7 @@ movement, a movement `order` below 1, a category setting both the slug and the
 raw bounds, a `weight_class_min` above its `weight_class_max`, an athlete setting both
 `bodyweight` and `ris`, a lift naming a
 movement not in `movements`, a lift with no attempts, an `attempt_number`
-outside 1 to 3, a negative weight.
+outside 1 to 3, a negative weight. Zero is allowed: it is a bodyweight-only lift.
 
 ### What it only warns about
 

--- a/backend/.sqlx/query-9f43d0d8428200ab5ff8d039fb88aafe01ed98feaefab0e27cd34db0395f9c70.json
+++ b/backend/.sqlx/query-9f43d0d8428200ab5ff8d039fb88aafe01ed98feaefab0e27cd34db0395f9c70.json
@@ -79,7 +79,7 @@
       false,
       false,
       false,
-      false,
+      true,
       true,
       true
     ]

--- a/backend/.sqlx/query-d5ad11b3793525e19a6f68c4a25e46af8c1030aaa652c7b9c45268e0215e5220.json
+++ b/backend/.sqlx/query-d5ad11b3793525e19a6f68c4a25e46af8c1030aaa652c7b9c45268e0215e5220.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT DISTINCT ON (l.movement_name)\n                l.movement_name,\n                l.max_weight,\n                c.name as competition_name,\n                c.slug as competition_slug,\n                c.start_date as date\n            FROM lifts l\n            JOIN competition_participants cp ON l.participant_id = cp.participant_id\n            JOIN competitions c ON cp.competition_id = c.competition_id\n            WHERE cp.athlete_id = $1\n            ORDER BY l.movement_name, l.max_weight DESC\n            ",
+  "query": "\n            SELECT DISTINCT ON (l.movement_name)\n                l.movement_name,\n                -- Not null thanks to the filter below, which sqlx cannot infer.\n                l.max_weight as \"max_weight!\",\n                c.name as competition_name,\n                c.slug as competition_slug,\n                c.start_date as date\n            FROM lifts l\n            JOIN competition_participants cp ON l.participant_id = cp.participant_id\n            JOIN competitions c ON cp.competition_id = c.competition_id\n            WHERE cp.athlete_id = $1\n              -- A movement where every attempt failed is not a record, and\n              -- DESC would otherwise sort its NULL to the front and pick it.\n              AND l.max_weight IS NOT NULL\n            ORDER BY l.movement_name, l.max_weight DESC\n            ",
   "describe": {
     "columns": [
       {
@@ -16,7 +16,7 @@
       },
       {
         "ordinal": 1,
-        "name": "max_weight",
+        "name": "max_weight!",
         "type_info": "Numeric",
         "origin": {
           "Table": {
@@ -66,11 +66,11 @@
     },
     "nullable": [
       false,
-      false,
+      true,
       false,
       false,
       false
     ]
   },
-  "hash": "43b0775a37dd25ac65ab7f14f419e2cfff7c5463ae484c4c7eaa7dfaac5d2d60"
+  "hash": "d5ad11b3793525e19a6f68c4a25e46af8c1030aaa652c7b9c45268e0215e5220"
 }

--- a/backend/crates/osl_api/src/competition/dto.rs
+++ b/backend/crates/osl_api/src/competition/dto.rs
@@ -94,7 +94,9 @@ pub struct AthleteInfo {
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct LiftDetail {
     pub movement_name: String,
-    pub best_weight: rust_decimal::Decimal,
+    /// Best successful attempt. Zero is a bodyweight-only lift, and absent
+    /// means the movement was contested with no attempt succeeding.
+    pub best_weight: Option<rust_decimal::Decimal>,
     pub attempts: Vec<AttemptInfo>,
 }
 

--- a/backend/crates/osl_db/migrations/20260812140000_zero_and_bombed_lifts.sql
+++ b/backend/crates/osl_db/migrations/20260812140000_zero_and_bombed_lifts.sql
@@ -1,0 +1,24 @@
+-- Two results the schema could not express, both ordinary in streetlifting.
+--
+-- A muscle-up with no added weight is a real, successful lift, recorded as
+-- 0 kg. `CHECK (weight > 0)` rejected it outright.
+--
+-- A movement where every attempt failed has no weight at all. The importer
+-- derives the stored weight from successful attempts, so it produced NULL and
+-- hit the NOT NULL, which meant a lifter who bombed one movement could not be
+-- imported even though the rest of their meet was fine.
+--
+-- The two must stay apart. 0 means they lifted their bodyweight and nothing
+-- more; NULL means they lifted nothing at all. Collapsing the second into the
+-- first would credit a lift that never happened.
+
+ALTER TABLE attempts DROP CONSTRAINT attempts_weight_check;
+ALTER TABLE attempts ADD CONSTRAINT attempts_weight_check CHECK (weight >= 0);
+
+ALTER TABLE lifts DROP CONSTRAINT lifts_max_weight_check;
+ALTER TABLE lifts ALTER COLUMN max_weight DROP NOT NULL;
+ALTER TABLE lifts ADD CONSTRAINT lifts_max_weight_check CHECK (max_weight >= 0);
+
+COMMENT ON COLUMN lifts.max_weight IS
+    'Best successful attempt. 0 is a bodyweight-only lift; NULL means the '
+    'movement was contested and no attempt succeeded.';

--- a/backend/crates/osl_db/src/projections/competition.rs
+++ b/backend/crates/osl_db/src/projections/competition.rs
@@ -41,7 +41,9 @@ pub struct ParticipantDetail {
 #[derive(Debug)]
 pub struct LiftDetail {
     pub movement_name: String,
-    pub best_weight: Decimal,
+    /// Best successful attempt. 0 is a bodyweight-only lift, and None means
+    /// the movement was contested with no attempt succeeding.
+    pub best_weight: Option<Decimal>,
     pub attempts: Vec<AttemptSummary>,
 }
 

--- a/backend/crates/osl_db/src/repository/athlete.rs
+++ b/backend/crates/osl_db/src/repository/athlete.rs
@@ -134,7 +134,8 @@ impl<'a> AthleteRepository<'a> {
             r#"
             SELECT DISTINCT ON (l.movement_name)
                 l.movement_name,
-                l.max_weight,
+                -- Not null thanks to the filter below, which sqlx cannot infer.
+                l.max_weight as "max_weight!",
                 c.name as competition_name,
                 c.slug as competition_slug,
                 c.start_date as date
@@ -142,6 +143,9 @@ impl<'a> AthleteRepository<'a> {
             JOIN competition_participants cp ON l.participant_id = cp.participant_id
             JOIN competitions c ON cp.competition_id = c.competition_id
             WHERE cp.athlete_id = $1
+              -- A movement where every attempt failed is not a record, and
+              -- DESC would otherwise sort its NULL to the front and pick it.
+              AND l.max_weight IS NOT NULL
             ORDER BY l.movement_name, l.max_weight DESC
             "#,
             athlete.athlete_id

--- a/backend/crates/osl_db/src/repository/competition.rs
+++ b/backend/crates/osl_db/src/repository/competition.rs
@@ -251,7 +251,7 @@ impl<'a> CompetitionRepository<'a> {
                     .fetch_all(self.pool)
                     .await?;
 
-                    total += lift.max_weight;
+                    total += lift.max_weight.unwrap_or(Decimal::ZERO);
 
                     lift_details.push(LiftDetail {
                         movement_name: lift.movement_name.clone(),

--- a/backend/crates/osl_db/src/rows/lift.rs
+++ b/backend/crates/osl_db/src/rows/lift.rs
@@ -7,7 +7,9 @@ pub struct LiftRow {
     pub lift_id: Uuid,
     pub participant_id: Uuid,
     pub movement_name: String,
-    pub max_weight: Decimal,
+    /// Best successful attempt. 0 is a bodyweight-only lift, and None means
+    /// the movement was contested with no attempt succeeding.
+    pub max_weight: Option<Decimal>,
     pub equipment_setting: Option<String>,
     pub updated_at: Option<chrono::NaiveDateTime>,
 }

--- a/backend/crates/osl_importer/tests/zero_and_bombed_lifts.rs
+++ b/backend/crates/osl_importer/tests/zero_and_bombed_lifts.rs
@@ -1,0 +1,234 @@
+//! Two results that look alike in a total and are nothing alike.
+//!
+//! A muscle-up with no added weight is a successful lift worth 0. A movement
+//! where every attempt failed is not a lift at all. Both contribute nothing to
+//! the total, so only the stored value tells them apart: 0 against NULL.
+
+use osl_db::params::{RankingFilter, RankingMovement};
+use osl_db::repository::ranking::RankingRepository;
+use osl_importer::canonical::{models::CanonicalFormat, transformer::CanonicalTransformer};
+use rust_decimal::Decimal;
+use serde_json::{Value, json};
+use sqlx::PgPool;
+
+fn lift(movement: &str, attempts: Vec<(&str, bool)>) -> Value {
+    json!({
+        "movement": movement,
+        "attempts": attempts.iter().enumerate().map(|(i, (w, ok))| json!({
+            "attempt_number": i as i16 + 1, "weight": w, "is_successful": ok
+        })).collect::<Vec<_>>(),
+    })
+}
+
+fn athlete(first: &str, last: &str, lifts: Vec<Value>) -> Value {
+    json!({
+        "first_name": first, "last_name": last, "country": "FR",
+        "bodyweight": 80, "status": "competed", "lifts": lifts,
+    })
+}
+
+fn meet(slug: &str, athletes: Vec<Value>) -> CanonicalFormat {
+    serde_json::from_value(json!({
+        "format_version": "1.5.0",
+        "source": { "type": "manual", "extracted_at": "2026-01-01T00:00:00Z", "extractor": "zero-lift-test" },
+        "competition": {
+            "name": slug, "slug": slug,
+            "federation": { "name": "Test Federation" },
+            "start_date": "2026-01-01", "end_date": "2026-01-01", "country": "FR",
+        },
+        "movements": [
+            { "name": "Muscle-up", "order": 1 }, { "name": "Pull-up", "order": 2 },
+            { "name": "Dips", "order": 3 }, { "name": "Squat", "order": 4 },
+        ],
+        "categories": [{
+            "name": "Men -80kg", "gender": "M", "weight_class_slug": "M-80",
+            "athletes": athletes,
+        }],
+    }))
+    .expect("test document should be a valid canonical file")
+}
+
+async fn import(pool: &PgPool, canonical: CanonicalFormat) {
+    CanonicalTransformer::new(pool)
+        .import_to_database(canonical)
+        .await
+        .expect("import should succeed");
+}
+
+async fn best(pool: &PgPool, last_name: &str, movement: &str) -> Option<Decimal> {
+    sqlx::query_scalar(
+        "SELECT l.max_weight FROM lifts l
+         JOIN competition_participants cp USING (participant_id)
+         JOIN athletes a USING (athlete_id)
+         WHERE a.last_name = $1 AND l.movement_name = $2",
+    )
+    .bind(last_name)
+    .bind(movement)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+/// Lifted bodyweight and nothing more, then missed twice going up.
+fn bodyweight_lifter() -> Value {
+    athlete(
+        "Swann",
+        "Bodyweight",
+        vec![
+            lift(
+                "Muscle-up",
+                vec![("0", true), ("2.5", false), ("2.5", false)],
+            ),
+            lift("Pull-up", vec![("30", true)]),
+            lift("Dips", vec![("70", true)]),
+            lift("Squat", vec![("150", true)]),
+        ],
+    )
+}
+
+/// Made two movements, missed every attempt in the other two.
+fn bomber() -> Value {
+    athlete(
+        "Tom",
+        "Bombed",
+        vec![
+            lift("Muscle-up", vec![("20", true), ("25", true), ("30", false)]),
+            lift("Pull-up", vec![("85", false), ("90", false), ("90", true)]),
+            lift("Dips", vec![("160", false), ("170", false), ("170", false)]),
+            lift(
+                "Squat",
+                vec![("260", false), ("260", false), ("260", false)],
+            ),
+        ],
+    )
+}
+
+#[sqlx::test(migrations = "../osl_db/migrations")]
+async fn a_bodyweight_lift_is_stored_as_zero(pool: PgPool) {
+    import(&pool, meet("test-meet", vec![bodyweight_lifter()])).await;
+
+    assert_eq!(
+        best(&pool, "Bodyweight", "Muscle-up").await,
+        Some(Decimal::ZERO),
+        "she lifted her bodyweight, which is a result rather than an absence"
+    );
+}
+
+#[sqlx::test(migrations = "../osl_db/migrations")]
+async fn a_bombed_movement_is_stored_as_absent(pool: PgPool) {
+    import(&pool, meet("test-meet", vec![bomber()])).await;
+
+    assert_eq!(
+        best(&pool, "Bombed", "Dips").await,
+        None,
+        "he lifted nothing, which must not read as having lifted zero"
+    );
+    assert_eq!(
+        best(&pool, "Bombed", "Pull-up").await,
+        Some(Decimal::from(90))
+    );
+}
+
+#[sqlx::test(migrations = "../osl_db/migrations")]
+async fn every_attempt_is_kept_including_the_failures(pool: PgPool) {
+    import(&pool, meet("test-meet", vec![bomber()])).await;
+
+    let attempts: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM attempts a
+         JOIN lifts l USING (lift_id)
+         WHERE l.movement_name = 'Squat'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(attempts, 3, "three missed squats are still three squats");
+}
+
+#[sqlx::test(migrations = "../osl_db/migrations")]
+async fn a_bombed_movement_costs_only_itself(pool: PgPool) {
+    import(&pool, meet("test-meet", vec![bomber()])).await;
+
+    let total: Option<Decimal> = sqlx::query_scalar(
+        "SELECT SUM(l.max_weight) FROM lifts l
+         JOIN competition_participants cp USING (participant_id)
+         JOIN athletes a USING (athlete_id)
+         WHERE a.last_name = 'Bombed'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    // 25 from the muscle-up plus 90 from the pull-up. The two bombs add nothing
+    // and take nothing away.
+    assert_eq!(total, Some(Decimal::from(115)));
+}
+
+#[sqlx::test(migrations = "../osl_db/migrations")]
+async fn a_bodyweight_lifter_still_appears_on_that_movement(pool: PgPool) {
+    import(
+        &pool,
+        meet("test-meet", vec![bodyweight_lifter(), bomber()]),
+    )
+    .await;
+
+    let filter = RankingFilter {
+        gender: None,
+        country: None,
+        movement: RankingMovement::Muscleup,
+        event: osl_domain::FULL_EVENT.to_string(),
+        offset: 0,
+        limit: 50,
+    };
+    let (rows, total) = RankingRepository::new(&pool)
+        .get_global_ranking(&filter)
+        .await
+        .unwrap();
+
+    let names: Vec<&str> = rows.iter().map(|r| r.last_name.as_str()).collect();
+    assert_eq!(names, vec!["Bombed", "Bodyweight"], "25 kg beats 0 kg");
+    assert_eq!(total, 2);
+}
+
+#[sqlx::test(migrations = "../osl_db/migrations")]
+async fn a_bomber_is_left_off_that_movements_board(pool: PgPool) {
+    import(
+        &pool,
+        meet("test-meet", vec![bodyweight_lifter(), bomber()]),
+    )
+    .await;
+
+    let filter = RankingFilter {
+        gender: None,
+        country: None,
+        movement: RankingMovement::Dips,
+        event: osl_domain::FULL_EVENT.to_string(),
+        offset: 0,
+        limit: 50,
+    };
+    let (rows, total) = RankingRepository::new(&pool)
+        .get_global_ranking(&filter)
+        .await
+        .unwrap();
+
+    let names: Vec<&str> = rows.iter().map(|r| r.last_name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["Bodyweight"],
+        "no successful dip means no place on the dip board"
+    );
+    assert_eq!(total, 1, "the count has to agree with the rows");
+}
+
+#[sqlx::test(migrations = "../osl_db/migrations")]
+async fn a_negative_weight_is_still_refused(pool: PgPool) {
+    import(&pool, meet("test-meet", vec![bodyweight_lifter()])).await;
+
+    let inserted = sqlx::query(
+        "INSERT INTO attempts (lift_id, attempt_number, weight, is_successful)
+         SELECT lift_id, 3, -5, false FROM lifts LIMIT 1",
+    )
+    .execute(&pool)
+    .await;
+
+    assert!(inserted.is_err(), "zero is a weight, below zero is not");
+}


### PR DESCRIPTION
A lifter who missed every attempt in one movement could not be imported at all, and a muscle-up with no added weight was rejected as if it were not a lift. Both are kept now, and they stay apart: zero means they lifted their bodyweight, absent means they lifted nothing.

Closes OPE-158