### PR TITLE
feat(importer): delete the competitions no file claims

### DIFF
--- a/backend/.sqlx/query-4c07b892a3e06886057737b889262ae5dbbfa0905542d007791e7a3ad36d79d9.json
+++ b/backend/.sqlx/query-4c07b892a3e06886057737b889262ae5dbbfa0905542d007791e7a3ad36d79d9.json
@@ -1,0 +1,38 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            DELETE FROM athletes\n            WHERE NOT EXISTS (\n                SELECT 1\n                FROM competition_participants cp\n                WHERE cp.athlete_id = athletes.athlete_id\n            )\n            RETURNING first_name, last_name\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "first_name",
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "athletes",
+            "name": "first_name"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "last_name",
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "athletes",
+            "name": "last_name"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "4c07b892a3e06886057737b889262ae5dbbfa0905542d007791e7a3ad36d79d9"
+}

--- a/backend/.sqlx/query-63c7658cad06892f3cb70bb67b32046fb83011fbb615aac1c5dbcbbb1e445df8.json
+++ b/backend/.sqlx/query-63c7658cad06892f3cb70bb67b32046fb83011fbb615aac1c5dbcbbb1e445df8.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            DELETE FROM competitions\n            WHERE slug <> ALL($1::text[])\n            RETURNING slug, name\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "slug",
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "competitions",
+            "name": "slug"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "competitions",
+            "name": "name"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "63c7658cad06892f3cb70bb67b32046fb83011fbb615aac1c5dbcbbb1e445df8"
+}

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1362,6 +1362,7 @@ dependencies = [
 name = "osl_importer"
 version = "0.6.0"
 dependencies = [
+ "anyhow",
  "chrono",
  "clap",
  "dotenvy",

--- a/backend/crates/osl_importer/Cargo.toml
+++ b/backend/crates/osl_importer/Cargo.toml
@@ -7,6 +7,7 @@ publish.workspace = true
 [dependencies]
 osl_db = { path = "../osl_db" }
 osl_domain = { path = "../osl_domain" }
+anyhow.workspace = true
 chrono.workspace = true
 clap = { version = "4.5.52", features = ["derive", "env"] }
 dotenvy.workspace = true

--- a/backend/crates/osl_importer/src/bin/import.rs
+++ b/backend/crates/osl_importer/src/bin/import.rs
@@ -1,8 +1,10 @@
+use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand};
 use osl_importer::canonical::{
     format as canonical_format, models::CanonicalFormat, transformer::CanonicalTransformer,
     validator::CanonicalValidator,
 };
+use osl_importer::sync::CompetitionSync;
 use sqlx::postgres::PgPoolOptions;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -38,6 +40,16 @@ enum Commands {
 
         #[arg(long)]
         validate_only: bool,
+
+        /// Delete the competitions no file in the tree claims, and the athletes
+        /// they leave without a result. Reports what it would delete unless
+        /// `--yes` is passed, and needs the whole imports tree to be right.
+        #[arg(long)]
+        prune: bool,
+
+        /// Carry out the prune instead of only reporting it.
+        #[arg(long)]
+        yes: bool,
     },
     /// Recompute every stored RIS score against the current formula.
     ///
@@ -57,7 +69,7 @@ enum Commands {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<()> {
     dotenvy::dotenv().ok();
 
     let cli = Cli::parse();
@@ -83,9 +95,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Commands::BulkImport {
             directory,
             validate_only,
+            prune,
+            yes,
         } => {
+            if prune && validate_only {
+                bail!("--prune writes to the database, so it cannot run with --validate-only");
+            }
+
             let database_url = require_database_url(cli.database_url.as_deref(), validate_only)?;
-            handle_bulk_import(directory, validate_only, database_url).await?;
+            handle_bulk_import(directory, validate_only, prune, yes, database_url).await?;
         }
         Commands::RecomputeRis => {
             let database_url = require_database_url(cli.database_url.as_deref(), false)?;
@@ -99,23 +117,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn require_database_url(
-    database_url: Option<&str>,
-    validate_only: bool,
-) -> Result<&str, Box<dyn std::error::Error>> {
+fn require_database_url(database_url: Option<&str>, validate_only: bool) -> Result<&str> {
     match database_url {
         Some(url) => Ok(url),
         None if validate_only => Ok(""),
-        None => Err("DATABASE_URL is required to import. Pass --validate-only to skip it".into()),
+        None => bail!("DATABASE_URL is required to import. Pass --validate-only to skip it"),
     }
 }
 
-async fn handle_recompute_ris(database_url: &str) -> Result<(), Box<dyn std::error::Error>> {
+async fn handle_recompute_ris(database_url: &str) -> Result<()> {
     tracing::info!("Connecting to database...");
     let pool = PgPoolOptions::new()
         .max_connections(5)
         .connect(database_url)
-        .await?;
+        .await
+        .context("connecting to the database")?;
 
     let count = osl_db::services::ris_computation::recompute_all_ris(&pool, None).await?;
     tracing::info!("✓ Recomputed RIS for {} participant(s)", count);
@@ -123,7 +139,7 @@ async fn handle_recompute_ris(database_url: &str) -> Result<(), Box<dyn std::err
     Ok(())
 }
 
-async fn handle_fmt(paths: &[PathBuf], check: bool) -> Result<(), Box<dyn std::error::Error>> {
+async fn handle_fmt(paths: &[PathBuf], check: bool) -> Result<()> {
     let mut files = Vec::new();
     for path in paths {
         collect_json_files(path, &mut files).await?;
@@ -162,11 +178,10 @@ async fn handle_fmt(paths: &[PathBuf], check: bool) -> Result<(), Box<dyn std::e
     }
 
     if check {
-        return Err(format!(
+        bail!(
             "{} file(s) are not formatted. Run `import fmt` to fix",
             changed.len()
-        )
-        .into());
+        );
     }
 
     tracing::info!("Formatted {} file(s)", changed.len());
@@ -177,7 +192,7 @@ async fn handle_canonical_import(
     file: PathBuf,
     validate_only: bool,
     database_url: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<()> {
     tracing::info!("Loading canonical JSON from: {}", file.display());
 
     let json_content = tokio::fs::read_to_string(&file).await?;
@@ -202,7 +217,8 @@ async fn handle_canonical_import(
     let pool = PgPoolOptions::new()
         .max_connections(5)
         .connect(database_url)
-        .await?;
+        .await
+        .context("connecting to the database")?;
 
     tracing::info!(
         "Importing {} categories to database...",
@@ -217,10 +233,7 @@ async fn handle_canonical_import(
 }
 
 /// Gathers every .json under `path`, or `path` itself when it is a file.
-async fn collect_json_files(
-    path: &Path,
-    found: &mut Vec<PathBuf>,
-) -> Result<(), Box<dyn std::error::Error>> {
+async fn collect_json_files(path: &Path, found: &mut Vec<PathBuf>) -> Result<()> {
     let mut pending = vec![path.to_path_buf()];
 
     while let Some(current) = pending.pop() {
@@ -240,13 +253,13 @@ async fn collect_json_files(
     Ok(())
 }
 
+/// The competitions this tree claims, which is also what a prune keeps.
+///
 /// An import owns its whole competition and removes the rows its file does not
 /// list, so two files claiming one slug would each delete the other's results.
 /// Sessions of the same meet belong in one file, and that has to hold before
 /// anything is written.
-async fn ensure_one_file_per_competition(
-    files: &[PathBuf],
-) -> Result<(), Box<dyn std::error::Error>> {
+async fn claimed_competition_slugs(files: &[PathBuf]) -> Result<Vec<String>> {
     let mut by_slug: BTreeMap<String, Vec<&PathBuf>> = BTreeMap::new();
 
     for file in files {
@@ -270,7 +283,7 @@ async fn ensure_one_file_per_competition(
         .collect();
 
     if clashes.is_empty() {
-        return Ok(());
+        return Ok(by_slug.into_keys().collect());
     }
 
     for (slug, files) in &clashes {
@@ -284,18 +297,19 @@ async fn ensure_one_file_per_competition(
         }
     }
 
-    Err(format!(
+    bail!(
         "{} competition slug(s) claimed by more than one file. Merge them into one file per competition",
         clashes.len()
     )
-    .into())
 }
 
 async fn handle_bulk_import(
     directory: PathBuf,
     validate_only: bool,
+    prune: bool,
+    yes: bool,
     database_url: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<()> {
     tracing::info!(
         "Scanning directory for canonical JSON files: {}",
         directory.display()
@@ -312,7 +326,7 @@ async fn handle_bulk_import(
     json_files.sort();
     tracing::info!("Found {} canonical JSON file(s)", json_files.len());
 
-    ensure_one_file_per_competition(&json_files).await?;
+    let claimed_slugs = claimed_competition_slugs(&json_files).await?;
 
     let pool = if !validate_only {
         tracing::info!("Connecting to database...");
@@ -320,7 +334,8 @@ async fn handle_bulk_import(
             PgPoolOptions::new()
                 .max_connections(5)
                 .connect(database_url)
-                .await?,
+                .await
+                .context("connecting to the database")?,
         )
     } else {
         None
@@ -356,7 +371,59 @@ async fn handle_bulk_import(
     );
 
     if error_count > 0 {
-        return Err(format!("{} file(s) failed to import", error_count).into());
+        if prune {
+            tracing::warn!("Skipping the prune: a file that failed to import claims nothing");
+        }
+        bail!("{} file(s) failed to import", error_count);
+    }
+
+    if prune && let Some(pool) = pool.as_ref() {
+        handle_prune(pool, &claimed_slugs, yes).await?;
+    }
+
+    Ok(())
+}
+
+async fn handle_prune(pool: &sqlx::PgPool, claimed_slugs: &[String], yes: bool) -> Result<()> {
+    let sync = CompetitionSync::new(pool);
+
+    let plan = if yes {
+        sync.apply(claimed_slugs).await?
+    } else {
+        sync.dry_run(claimed_slugs).await?
+    };
+
+    if plan.is_empty() {
+        tracing::info!("Nothing to prune: every stored competition is claimed by a file");
+        return Ok(());
+    }
+
+    if !plan.competitions.is_empty() {
+        tracing::info!("Competitions no file claims:");
+        for competition in &plan.competitions {
+            tracing::info!("  {} ({})", competition.slug, competition.name);
+        }
+    }
+
+    if !plan.athletes.is_empty() {
+        tracing::info!("Athletes left without a result:");
+        for athlete in &plan.athletes {
+            tracing::info!("  {}", athlete);
+        }
+    }
+
+    if yes {
+        tracing::info!(
+            "Deleted {} competition(s) and {} athlete(s)",
+            plan.competitions.len(),
+            plan.athletes.len()
+        );
+    } else {
+        tracing::warn!(
+            "Would delete {} competition(s) and {} athlete(s). Pass --yes to carry it out",
+            plan.competitions.len(),
+            plan.athletes.len()
+        );
     }
 
     Ok(())
@@ -366,7 +433,7 @@ async fn process_canonical_file(
     file_path: &PathBuf,
     validate_only: bool,
     pool: Option<&sqlx::PgPool>,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<()> {
     let json_content = tokio::fs::read_to_string(file_path).await?;
     let canonical: CanonicalFormat = serde_json::from_str(&json_content)?;
 

--- a/backend/crates/osl_importer/src/lib.rs
+++ b/backend/crates/osl_importer/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod canonical;
 pub mod error;
+pub mod sync;
 
 pub use error::{ImporterError, Result};

--- a/backend/crates/osl_importer/src/sync.rs
+++ b/backend/crates/osl_importer/src/sync.rs
@@ -1,0 +1,108 @@
+//! Bringing the database back to what the canonical files say.
+//!
+//! The files are the data, so a competition no file claims should not exist,
+//! and neither should an athlete left without a single result.
+
+use sqlx::PgPool;
+
+use crate::error::{ImporterError, Result};
+
+pub struct CompetitionSync<'a> {
+    pool: &'a PgPool,
+}
+
+#[derive(Debug, Default)]
+pub struct SyncPlan {
+    pub competitions: Vec<DeletedCompetition>,
+    pub athletes: Vec<String>,
+}
+
+#[derive(Debug)]
+pub struct DeletedCompetition {
+    pub slug: String,
+    pub name: String,
+}
+
+impl SyncPlan {
+    pub fn is_empty(&self) -> bool {
+        self.competitions.is_empty() && self.athletes.is_empty()
+    }
+}
+
+impl<'a> CompetitionSync<'a> {
+    pub fn new(pool: &'a PgPool) -> Self {
+        Self { pool }
+    }
+
+    /// What `apply` would delete, worked out by doing it and rolling back, so
+    /// the report can never disagree with what follows it.
+    pub async fn dry_run(&self, claimed_slugs: &[String]) -> Result<SyncPlan> {
+        let mut tx = self.pool.begin().await?;
+        let plan = Self::purge(claimed_slugs, &mut tx).await?;
+        tx.rollback().await?;
+
+        Ok(plan)
+    }
+
+    pub async fn apply(&self, claimed_slugs: &[String]) -> Result<SyncPlan> {
+        let mut tx = self.pool.begin().await?;
+        let plan = Self::purge(claimed_slugs, &mut tx).await?;
+        tx.commit().await?;
+
+        Ok(plan)
+    }
+
+    /// Claiming nothing would mean deleting every competition, which is what a
+    /// mistyped directory looks like, so it is refused rather than obeyed.
+    async fn purge(
+        claimed_slugs: &[String],
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    ) -> Result<SyncPlan> {
+        if claimed_slugs.is_empty() {
+            return Err(ImporterError::ImportError(
+                "no canonical file claims a competition, so every stored competition would go. \
+                 Point the import at the whole imports tree"
+                    .to_string(),
+            ));
+        }
+
+        let competitions = sqlx::query!(
+            r#"
+            DELETE FROM competitions
+            WHERE slug <> ALL($1::text[])
+            RETURNING slug, name
+            "#,
+            claimed_slugs
+        )
+        .fetch_all(&mut **tx)
+        .await?;
+
+        let athletes = sqlx::query!(
+            r#"
+            DELETE FROM athletes
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM competition_participants cp
+                WHERE cp.athlete_id = athletes.athlete_id
+            )
+            RETURNING first_name, last_name
+            "#
+        )
+        .fetch_all(&mut **tx)
+        .await?;
+
+        Ok(SyncPlan {
+            competitions: competitions
+                .into_iter()
+                .map(|row| DeletedCompetition {
+                    slug: row.slug,
+                    name: row.name,
+                })
+                .collect(),
+            athletes: athletes
+                .into_iter()
+                .map(|row| format!("{} {}", row.first_name, row.last_name))
+                .collect(),
+        })
+    }
+}

--- a/backend/crates/osl_importer/tests/file_deletion.rs
+++ b/backend/crates/osl_importer/tests/file_deletion.rs
@@ -1,0 +1,197 @@
+//! Deleting a canonical file has to delete its competition, since the files are
+//! the data. What it must not take with it is the reference data and the
+//! athletes who lifted somewhere else too.
+
+use osl_importer::canonical::{models::CanonicalFormat, transformer::CanonicalTransformer};
+use osl_importer::sync::CompetitionSync;
+use serde_json::{Value, json};
+use sqlx::PgPool;
+
+fn lift(movement: &str, weight: i32) -> Value {
+    json!({
+        "movement": movement,
+        "attempts": [{ "attempt_number": 1, "weight": weight, "is_successful": true }],
+    })
+}
+
+fn athlete(first: &str, last: &str) -> Value {
+    json!({
+        "first_name": first, "last_name": last, "country": "FR",
+        "bodyweight": 80, "status": "competed",
+        "lifts": [lift("Muscle-up", 40), lift("Pull-up", 90)],
+    })
+}
+
+fn meet(slug: &str, athletes: Vec<Value>) -> CanonicalFormat {
+    serde_json::from_value(json!({
+        "format_version": "1.5.0",
+        "source": { "type": "manual", "extracted_at": "2026-01-01T00:00:00Z", "extractor": "file-deletion-test" },
+        "competition": {
+            "name": slug, "slug": slug,
+            "federation": { "name": "Test Federation" },
+            "start_date": "2026-01-01", "end_date": "2026-01-01", "country": "FR",
+        },
+        "movements": [
+            { "name": "Muscle-up", "order": 1 }, { "name": "Pull-up", "order": 2 },
+        ],
+        "categories": [{
+            "name": "Men -80kg", "gender": "M", "weight_class_slug": "M-80",
+            "athletes": athletes,
+        }],
+    }))
+    .expect("test document should be a valid canonical file")
+}
+
+async fn import(pool: &PgPool, canonical: CanonicalFormat) {
+    CanonicalTransformer::new(pool)
+        .import_to_database(canonical)
+        .await
+        .expect("import should succeed");
+}
+
+/// One meet whose file is still there, one whose file was deleted, and a lifter
+/// who was at both.
+async fn two_meets(pool: &PgPool) {
+    import(
+        pool,
+        meet(
+            "kept-meet",
+            vec![athlete("Clara", "Clean"), athlete("Sam", "Shared")],
+        ),
+    )
+    .await;
+    import(
+        pool,
+        meet(
+            "gone-meet",
+            vec![athlete("Sam", "Shared"), athlete("Gil", "Gone")],
+        ),
+    )
+    .await;
+}
+
+async fn count(pool: &PgPool, query: &'static str) -> i64 {
+    sqlx::query_scalar(query).fetch_one(pool).await.unwrap()
+}
+
+async fn slugs(pool: &PgPool) -> Vec<String> {
+    sqlx::query_scalar("SELECT slug FROM competitions ORDER BY slug")
+        .fetch_all(pool)
+        .await
+        .unwrap()
+}
+
+async fn last_names(pool: &PgPool) -> Vec<String> {
+    sqlx::query_scalar("SELECT last_name FROM athletes ORDER BY last_name")
+        .fetch_all(pool)
+        .await
+        .unwrap()
+}
+
+#[sqlx::test(migrations = "../osl_db/migrations")]
+async fn a_competition_no_file_claims_is_deleted(pool: PgPool) {
+    two_meets(&pool).await;
+
+    let plan = CompetitionSync::new(&pool)
+        .apply(&["kept-meet".to_string()])
+        .await
+        .unwrap();
+
+    assert_eq!(slugs(&pool).await, vec!["kept-meet"]);
+    assert_eq!(
+        plan.competitions
+            .iter()
+            .map(|c| c.slug.as_str())
+            .collect::<Vec<_>>(),
+        vec!["gone-meet"],
+        "the plan has to name what it deleted"
+    );
+
+    assert_eq!(
+        count(&pool, "SELECT COUNT(*) FROM competition_participants").await,
+        2
+    );
+    assert_eq!(count(&pool, "SELECT COUNT(*) FROM lifts").await, 4);
+    assert_eq!(
+        count(&pool, "SELECT COUNT(*) FROM attempts").await,
+        4,
+        "the attempts of a deleted competition go with it"
+    );
+}
+
+#[sqlx::test(migrations = "../osl_db/migrations")]
+async fn an_athlete_left_with_no_result_goes_too(pool: PgPool) {
+    two_meets(&pool).await;
+
+    CompetitionSync::new(&pool)
+        .apply(&["kept-meet".to_string()])
+        .await
+        .unwrap();
+
+    assert_eq!(
+        last_names(&pool).await,
+        vec!["Clean", "Shared"],
+        "Gone only ever lifted at the deleted meet, Shared was at both"
+    );
+}
+
+#[sqlx::test(migrations = "../osl_db/migrations")]
+async fn reference_data_is_left_alone(pool: PgPool) {
+    two_meets(&pool).await;
+
+    let movements = count(&pool, "SELECT COUNT(*) FROM movements").await;
+    let weight_classes = count(&pool, "SELECT COUNT(*) FROM weight_classes").await;
+
+    CompetitionSync::new(&pool)
+        .apply(&["kept-meet".to_string()])
+        .await
+        .unwrap();
+
+    assert_eq!(count(&pool, "SELECT COUNT(*) FROM federations").await, 1);
+    assert_eq!(count(&pool, "SELECT COUNT(*) FROM categories").await, 1);
+    assert_eq!(
+        count(&pool, "SELECT COUNT(*) FROM movements").await,
+        movements
+    );
+    assert_eq!(
+        count(&pool, "SELECT COUNT(*) FROM weight_classes").await,
+        weight_classes
+    );
+}
+
+#[sqlx::test(migrations = "../osl_db/migrations")]
+async fn claiming_nothing_is_refused(pool: PgPool) {
+    two_meets(&pool).await;
+
+    let refused = CompetitionSync::new(&pool).apply(&[]).await;
+
+    assert!(
+        refused.is_err(),
+        "an empty tree means a mistake, not an instruction to delete everything"
+    );
+    assert_eq!(slugs(&pool).await, vec!["gone-meet", "kept-meet"]);
+}
+
+#[sqlx::test(migrations = "../osl_db/migrations")]
+async fn a_dry_run_reports_without_deleting(pool: PgPool) {
+    two_meets(&pool).await;
+
+    let plan = CompetitionSync::new(&pool)
+        .dry_run(&["kept-meet".to_string()])
+        .await
+        .unwrap();
+
+    assert_eq!(
+        plan.competitions
+            .iter()
+            .map(|c| c.slug.as_str())
+            .collect::<Vec<_>>(),
+        vec!["gone-meet"]
+    );
+    assert_eq!(plan.athletes, vec!["Gil Gone"]);
+    assert_eq!(
+        slugs(&pool).await,
+        vec!["gone-meet", "kept-meet"],
+        "reporting must not be a deletion"
+    );
+}


### PR DESCRIPTION
Deleting a canonical file removed the claim but left the competition being served, because a bulk import only ever wrote what the files listed and never asked the database what nothing claimed any more. `bulk-import --prune` now deletes the competitions no file in the tree claims, along with the athletes that leaves without a single result, so the database ends up where a wipe and a fresh import would put it. It reports what it would delete and does nothing until you pass `--yes`, and that report is produced by carrying out the deletion in a transaction and rolling it back, so it cannot disagree with what follows. Claiming nothing at all is refused rather than obeyed, since an empty tree is what a wrong directory looks like and not an instruction to empty the database, and a file that fails to import cancels the prune because a file nobody could parse claims nothing.

Closes OPE-165
Closes #240