### PR TITLE
chore(ci): build and push the importer image

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -42,6 +42,39 @@ jobs:
           cache-to: type=gha,scope=backend,mode=max
           build-args: BIN=osl_api
 
+  build-importer:
+    name: Build & Push Importer
+    runs-on: ubuntu-latest
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.name == 'Backend CI'
+    outputs:
+      sha_tag: ${{ steps.sha_tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+      - name: Set SHA tag
+        id: sha_tag
+        run: |
+          echo "tag=sha-$(echo '${{ github.event.workflow_run.head_sha }}' | cut -c1-7)" >> "$GITHUB_OUTPUT"
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v7
+        with:
+          context: backend
+          push: true
+          platforms: linux/amd64
+          tags: ${{ env.REGISTRY }}/openstreetlifting/importer:${{ steps.sha_tag.outputs.tag }}
+          cache-from: type=gha,scope=importer
+          cache-to: type=gha,scope=importer,mode=max
+          build-args: BIN=import
+
   build-frontend:
     name: Build & Push Frontend
     runs-on: ubuntu-latest
@@ -77,7 +110,7 @@ jobs:
   update-chart:
     name: Update Chart
     runs-on: ubuntu-latest
-    needs: [build-backend, build-frontend]
+    needs: [build-backend, build-importer, build-frontend]
     if: always() && !contains(needs.*.result, 'failure')
     steps:
       - uses: actions/create-github-app-token@v2
@@ -97,6 +130,10 @@ jobs:
         run: |
           if [[ "${{ needs.build-backend.result }}" == "success" ]]; then
             yq -i ".backend.image.tag = \"${{ needs.build-backend.outputs.sha_tag }}\"" \
+              charts/values.yaml
+          fi
+          if [[ "${{ needs.build-importer.result }}" == "success" ]]; then
+            yq -i ".importer.image.tag = \"${{ needs.build-importer.outputs.sha_tag }}\"" \
               charts/values.yaml
           fi
           if [[ "${{ needs.build-frontend.result }}" == "success" ]]; then

--- a/.github/workflows/release-deploy.yaml
+++ b/.github/workflows/release-deploy.yaml
@@ -45,6 +45,7 @@ jobs:
         run: |
           echo "frontend_sha=$(yq '.frontend.image.tag' charts/values.yaml)" >> "$GITHUB_OUTPUT"
           echo "backend_sha=$(yq '.backend.image.tag' charts/values.yaml)" >> "$GITHUB_OUTPUT"
+          echo "importer_sha=$(yq '.importer.image.tag' charts/values.yaml)" >> "$GITHUB_OUTPUT"
           echo "semver=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Retag frontend image
@@ -61,10 +62,18 @@ jobs:
             -t ${{ env.REGISTRY }}/openstreetlifting/backend:latest \
             ${{ env.REGISTRY }}/openstreetlifting/backend:${{ steps.tags.outputs.backend_sha }}
 
+      - name: Retag importer image
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.REGISTRY }}/openstreetlifting/importer:${{ steps.tags.outputs.semver }} \
+            -t ${{ env.REGISTRY }}/openstreetlifting/importer:latest \
+            ${{ env.REGISTRY }}/openstreetlifting/importer:${{ steps.tags.outputs.importer_sha }}
+
       - name: Pin chart to semver
         run: |
           yq -i ".frontend.image.tag = \"${{ steps.tags.outputs.semver }}\"" charts/values.yaml
           yq -i ".backend.image.tag = \"${{ steps.tags.outputs.semver }}\"" charts/values.yaml
+          yq -i ".importer.image.tag = \"${{ steps.tags.outputs.semver }}\"" charts/values.yaml
           git config user.name "osl-ci[bot]"
           git config user.email "315316499+osl-ci[bot]@users.noreply.github.com"
           git checkout main

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -23,6 +23,11 @@ backend:
   database:
     secretName: osl-postgres-app
     urlKey: uri
+importer:
+  image:
+    repository: ghcr.io/openstreetlifting/importer
+    tag: sha-9df75f3
+    pullPolicy: IfNotPresent
 ingress:
   frontendHost: "localhost"
   backendHost: "localhost"


### PR DESCRIPTION
Delivery only ever built `BIN=osl_api`, so no importer image existed and every production import ran through a port-forward from a laptop. A third job now builds the same Dockerfile with `BIN=import`, pushes `ghcr.io/openstreetlifting/importer` on the same sha tag as the backend, and the release retag hands it the semver and latest alongside the other two, with the tag carried in `charts/values.yaml` so a chart can pin importer and backend to the same commit. The build arg is `import` and not `osl_importer` as the issue said, because the crate's only bin target comes from `src/bin/import.rs`. Verified by building the image from a clean export of the tree and running it.

Two things the image still cannot do, both belonging to OPE-53: it carries no canonical files, since the runtime stage copies only the binary, and it declares no ENTRYPOINT, so a Job has to set `command` as well as `args`.

Closes OPE-93
Closes #157