### PR TITLE
feat(chart): import the canonical files on every deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,36 @@ Contributions are welcome, whether you are fixing a bug, improving the codebase,
 For code contributions, fork the repository, create a branch from main, and open a pull request. Commits must follow the Conventional Commits specification, as releases are automated via google release-please.
 For data contributions, the entry point is the [canonical format](https://docs.openstreetlifting.org). If you have results from a competition that is not yet in the archive, create a canonical JSON file under backend/imports/{competition-slug}/ following the existing structure and open a pull request.
 
+## Importing in the cluster
+
+The canonical files are the data, so every deploy makes the database match them.
+The chart runs an import Job as a `post-upgrade` hook, which Argo CD runs as a
+PostSync once the release is healthy, so the import lands behind the backend that
+applies migrations. The importer image carries the whole `backend/imports` tree,
+which is why a merged data pull request reaches production on its own. Deletions
+are included: a competition no file claims is removed, along with the athletes
+that leaves without a result.
+
+To have a release import without deleting, drop `--yes` from `importer.args` and
+it only reports what it would remove.
+
+To run an import outside a deploy, render the on demand Job:
+
+```sh
+helm template charts -s templates/importer-job.yaml \
+  --set importer.job.enabled=true \
+  | kubectl create -f -
+```
+
+Any other importer command works the same way, for example a single file:
+
+```sh
+helm template charts -s templates/importer-job.yaml \
+  --set importer.job.enabled=true \
+  --set-json 'importer.args=["canonical","imports/fnsl-elite-2026/fnsl-elite-2026.json"]' \
+  | kubectl create -f -
+```
+
 ## Data Correction
 
 All competition data in this archive is versioned and traceable. If you spot an error, a wrong lift result, an incorrect athlete name, a missing competition, you can report or fix it directly.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -30,6 +30,10 @@ WORKDIR /app
 ARG BIN
 ENV BIN=${BIN}
 COPY --chown=appuser:appuser --from=builder /app/target/release/${BIN} /app/server
+# The canonical files are the data, so the importer image carries the whole tree
+# it is expected to reconcile against. Shipping a partial one would make a prune
+# delete competitions that only look unclaimed.
+COPY --chown=appuser:appuser --from=builder /app/imports /app/imports
 USER appuser
 EXPOSE 8080
-CMD ["/app/server"]
+ENTRYPOINT ["/app/server"]

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -13,3 +13,26 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/name: openstreetlifting-backend
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{- define "openstreetlifting.importer.selectorLabels" -}}
+app.kubernetes.io/name: openstreetlifting-importer
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "openstreetlifting.importer.podSpec" -}}
+restartPolicy: Never
+containers:
+  - name: importer
+    image: "{{ .Values.importer.image.repository }}:{{ .Values.importer.image.tag }}"
+    imagePullPolicy: {{ .Values.importer.image.pullPolicy }}
+    args:
+      {{- toYaml .Values.importer.args | nindent 6 }}
+    env:
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: {{ .Values.backend.database.secretName }}
+            key: {{ .Values.backend.database.urlKey }}
+    resources:
+      {{- toYaml .Values.importer.resources | nindent 6 }}
+{{- end }}

--- a/charts/templates/importer-hook-job.yaml
+++ b/charts/templates/importer-hook-job.yaml
@@ -1,0 +1,23 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: openstreetlifting-import
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openstreetlifting.labels" . | nindent 4 }}
+    {{- include "openstreetlifting.importer.selectorLabels" . | nindent 4 }}
+  annotations:
+    # Argo CD turns this into a PostSync hook, which waits for the rest of the
+    # release to report healthy. That is what keeps the import behind the new
+    # backend, which is the only thing that runs migrations.
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+spec:
+  backoffLimit: {{ .Values.importer.backoffLimit }}
+  ttlSecondsAfterFinished: {{ .Values.importer.ttlSecondsAfterFinished }}
+  template:
+    metadata:
+      labels:
+        {{- include "openstreetlifting.importer.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- include "openstreetlifting.importer.podSpec" . | nindent 6 }}

--- a/charts/templates/importer-job.yaml
+++ b/charts/templates/importer-job.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.importer.job.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: openstreetlifting-importer-
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openstreetlifting.labels" . | nindent 4 }}
+    {{- include "openstreetlifting.importer.selectorLabels" . | nindent 4 }}
+  annotations:
+    # This one is created by hand and lives outside git, so Argo CD must not
+    # treat it as drift and prune it out from under a running import.
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+spec:
+  backoffLimit: {{ .Values.importer.backoffLimit }}
+  ttlSecondsAfterFinished: {{ .Values.importer.ttlSecondsAfterFinished }}
+  template:
+    metadata:
+      labels:
+        {{- include "openstreetlifting.importer.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- include "openstreetlifting.importer.podSpec" . | nindent 6 }}
+{{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -28,6 +28,22 @@ importer:
     repository: ghcr.io/openstreetlifting/importer
     tag: sha-9df75f3
     pullPolicy: IfNotPresent
+  # Every deploy makes the database match the canonical files, deletions
+  # included. Drop --yes to have a release only report what it would remove.
+  args: ["bulk-import", "--prune", "--yes"]
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 1000m
+      memory: 512Mi
+  # Rendered on demand for a run outside a deploy, never installed with the
+  # release.
+  job:
+    enabled: false
 ingress:
   frontendHost: "localhost"
   backendHost: "localhost"


### PR DESCRIPTION
Nothing could run an import against production, so every one went through a port-forward from a laptop. The importer image now carries the whole `backend/imports` tree and gets an `ENTRYPOINT`, and the chart runs it as a `post-install,post-upgrade` hook, which Argo CD executes as a PostSync once the release reports healthy, keeping the import behind the backend that applies migrations. A merged data pull request therefore reaches production on its own: CI builds the image with the new files, delivery bumps the tag, the sync imports and prunes. Deletions are included by default, and dropping `--yes` from `importer.args` turns a release into a report. For a run outside a deploy, an on-demand Job renders from the chart with overridable args, annotated `IgnoreExtraneous` so automated prune leaves it alone mid-import.

Two things before this is live. `importer.image.tag` still names a tag that does not exist, since no importer image has been built yet: the CD job added in #242 only fires on a `backend/**` change, and this branch is the first one. Merging triggers it, at the cost of one failed PostSync until the bump commit lands. The `importer` package will also be created private, so it needs making public like backend and frontend, or the Job cannot pull it.

Closes OPE-53
Closes #82
Closes #63